### PR TITLE
Implement named provider and evaluation context merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ anyhow = "1.0"
 async-trait = "0.1.73"
 lazy_static = "1.4.0"
 time = "0.3.28"
+tokio = { version = "1.32.0", features = [ "full" ] }
 typed-builder = "0.16.0"
 
 [dev-dependencies]
-tokio = { version = "1.32.0", features = [ "full" ] }
+mockall = "0.11.4"
 spec = { path = "spec" }

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -13,7 +13,7 @@ use super::{
 lazy_static! {
     /// The singleton instance of [`OpenFeature`] struct.
     /// The client should always use this instance to access OpenFeature APIs.
-    pub static ref SINGLETON: RwLock<OpenFeature> = RwLock::new(OpenFeature::default());
+    static ref SINGLETON: RwLock<OpenFeature> = RwLock::new(OpenFeature::default());
 }
 
 /// THE struct of the OpenFeature API.
@@ -48,13 +48,18 @@ impl OpenFeature {
 
     /// Return the metadata of default (unnamed) provider.
     pub async fn provider_metadata(&self) -> ProviderMetadata {
-        self.provider_registry.get_default().await.get().metadata()
+        self.provider_registry
+            .get_default()
+            .await
+            .get()
+            .metadata()
+            .clone()
     }
 
     /// Return the metadata of named provider (a provider bound to clients with this name).
     pub async fn named_provider_metadata(&self, name: &str) -> Option<ProviderMetadata> {
         match self.provider_registry.get_named(name).await {
-            Some(provider) => Some(provider.get().metadata()),
+            Some(provider) => Some(provider.get().metadata().clone()),
             None => None,
         }
     }

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -1,106 +1,127 @@
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
-
 use lazy_static::lazy_static;
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::{
-    provider::{FeatureProvider, NoOpProvider, ProviderMetadata},
+    provider::{FeatureProvider, ProviderMetadata},
     Client, EvaluationContext,
 };
+
+use super::provider_registry::ProviderRegistry;
 
 lazy_static! {
     /// The singleton instance of [`OpenFeature`] struct.
     /// The client should always use this instance to access OpenFeature APIs.
-    pub static ref SINGLETON: RwLock<OpenFeature> = RwLock::new(OpenFeature {
-        provider: Arc::new(NoOpProvider::default()),
-        evaluation_context: EvaluationContext::default()
-    });
+    pub static ref SINGLETON: RwLock<OpenFeature> = RwLock::new(OpenFeature::default());
 }
 
 /// THE struct of the OpenFeature API.
 /// Access it via the [`SINGLETON`] instance.
+#[derive(Default)]
 pub struct OpenFeature {
-    provider: Arc<dyn FeatureProvider>,
+    providers: ProviderRegistry,
     evaluation_context: EvaluationContext,
 }
 
 impl OpenFeature {
-    pub fn singleton() -> RwLockReadGuard<'static, Self> {
-        SINGLETON.read().unwrap()
+    /// Get the singleton of [`OpenFeature`].
+    pub async fn singleton() -> RwLockReadGuard<'static, Self> {
+        SINGLETON.read().await
     }
 
-    pub fn singleton_mut() -> RwLockWriteGuard<'static, Self> {
-        SINGLETON.write().unwrap()
+    /// Get a mutable singleton of [`OpenFeature`].
+    pub async fn singleton_mut() -> RwLockWriteGuard<'static, Self> {
+        SINGLETON.write().await
     }
 
-    pub fn set_provider<T>(&mut self, provider: T)
-    where
-        T: FeatureProvider,
-    {
-        self.provider = Arc::new(provider);
+    /// Set the default provider.
+    pub async fn set_provider<T: FeatureProvider>(&mut self, provider: T) {
+        self.providers.set_default(provider).await;
     }
 
-    pub fn provider_metadata(&self) -> &ProviderMetadata {
-        self.provider.metadata()
+    /// Bind the given `provider` to the corresponding `name`.
+    pub async fn set_named_provider<T: FeatureProvider>(&mut self, name: &str, provider: T) {
+        self.providers.set_named(name, provider).await;
     }
 
+    /// Return the metadata of default (unnamed) provider.
+    pub async fn provider_metadata(&self) -> ProviderMetadata {
+        self.providers.get_default().await.get().metadata()
+    }
+
+    /// Return the metadata of named provider (a provider bound to clients with this name).
+    pub async fn named_provider_metadata(&self, name: &str) -> Option<ProviderMetadata> {
+        match self.providers.get_named(name).await {
+            Some(provider) => Some(provider.get().metadata()),
+            None => None,
+        }
+    }
+
+    /// Create a new client with default name.
     pub fn get_client(&self) -> Client {
-        Client::new(String::default(), self.provider.clone())
+        Client::new(String::default(), self.providers.clone())
     }
 
-    pub fn get_named_client(&self, name: String) -> Client {
-        Client::new(name, self.provider.clone())
+    /// Create a new client with specific `name`.
+    /// It will use the provider bound to this name, if any.
+    pub fn get_named_client(&self, name: &str) -> Client {
+        Client::new(name.to_string(), self.providers.clone())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-
     use super::*;
     use crate::provider::*;
     use spec::spec;
 
-    impl OpenFeature {
-        pub fn new<T: FeatureProvider>(provider: T, evaluation_context: EvaluationContext) -> Self {
-            Self {
-                provider: Arc::new(provider),
-                evaluation_context,
-            }
-        }
-    }
-
     #[tokio::test]
-    #[spec(number="1.1.2.1",text="The API MUST define a provider mutator, a function to set the default provider, which accepts an API-conformant provider implementation.")]
-    async fn set_provider() {
-        let provider = FixedValueProvider::builder().bool_value(true).build();
-
-        let api = OpenFeature::new(provider, EvaluationContext::default());
-
-        let client = api.get_client();
-        let value = client.get_bool_value("some-key", false, None).await;
-
-        assert_eq!(true, value);
-    }
-
-    #[tokio::test]
-    async fn test_singleton_multi_thread() {
-        let reader1 = thread::spawn(|| {
-            let _ = OpenFeature::singleton().provider_metadata();
+    #[spec(
+        number = "1.1.1",
+        text = "The API, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the API are present at runtime."
+    )]
+    async fn singleton_multi_thread() {
+        let reader1 = tokio::spawn(async move {
+            let _ = OpenFeature::singleton().await.provider_metadata();
         });
 
-        let writer = thread::spawn(|| {
-            OpenFeature::singleton_mut().set_provider(FixedValueProvider::default());
+        let writer = tokio::spawn(async move {
+            OpenFeature::singleton_mut()
+                .await
+                .set_provider(FixedValueProvider::default())
+                .await;
         });
 
-        let reader2 = thread::spawn(|| {
-            let _ = OpenFeature::singleton().provider_metadata();
+        let reader2 = tokio::spawn(async move {
+            let _ = OpenFeature::singleton().await.provider_metadata();
         });
 
-        let _ = (reader1.join(), reader2.join(), writer.join());
+        let _ = (reader1.await, reader2.await, writer.await);
 
         assert_eq!(
             "Fixed Value",
-            OpenFeature::singleton().provider_metadata().name
+            OpenFeature::singleton()
+                .await
+                .provider_metadata()
+                .await
+                .name
         );
+    }
+
+    #[tokio::test]
+    #[spec(
+        number = "1.1.2.1",
+        text = "The API MUST define a provider mutator, a function to set the default provider, which accepts an API-conformant provider implementation."
+    )]
+    async fn set_provider() {
+        let mut api = OpenFeature::default();
+        let client = api.get_client();
+
+        assert_eq!(client.get_int_value("some-key", 32, None).await, 32);
+
+        // Set the new provider and ensure the value comes from it.
+        let provider = FixedValueProvider::builder().int_value(200).build();
+        api.set_provider(provider).await;
+
+        assert_eq!(client.get_int_value("some-key", 100, None).await, 200);
     }
 }

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -22,7 +22,7 @@ lazy_static! {
 pub struct OpenFeature {
     evaluation_context: GlobalEvaluationContext,
 
-    pub provider_registry: ProviderRegistry,
+    provider_registry: ProviderRegistry,
 }
 
 impl OpenFeature {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -7,13 +7,7 @@ use super::{
 
 /// The metadata of OpenFeature client.
 pub struct ClientMetadata {
-    name: String,
-}
-
-impl ClientMetadata {
-    pub fn name(&self) -> &str {
-        &self.name.as_ref()
-    }
+    pub name: String,
 }
 
 /// The OpenFeature client.

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
+use crate::{EvaluationContext, StructValue};
 
-use crate::{provider::FeatureProvider, EvaluationContext, StructValue};
+use super::provider_registry::{self, FeatureProviderWrapper, ProviderRegistry};
 
 /// The metadata of OpenFeature client.
 pub struct ClientMetadata {
@@ -11,22 +11,17 @@ pub struct ClientMetadata {
 /// Create it through the [`OpenFeature`] struct.
 pub struct Client {
     pub metadata: ClientMetadata,
-    provider: Arc<dyn FeatureProvider>,
+    providers: ProviderRegistry,
     evaluation_context: EvaluationContext,
 }
 
 impl Client {
-    pub fn new(name: String, provider: Arc<dyn FeatureProvider>) -> Self {
+    pub fn new(name: String, providers: ProviderRegistry) -> Self {
         Self {
             metadata: ClientMetadata { name },
-            provider,
+            providers,
             evaluation_context: EvaluationContext::default(),
         }
-    }
-
-    pub fn with_evaluation_context(mut self, evaluation_context: EvaluationContext) -> Self {
-        self.evaluation_context = evaluation_context;
-        self
     }
 
     pub async fn get_bool_value(
@@ -35,7 +30,9 @@ impl Client {
         default_value: bool,
         evaluation_context: Option<&EvaluationContext>,
     ) -> bool {
-        self.provider
+        self.get_provider()
+            .await
+            .get()
             .resolve_bool_value(flag_key, default_value, evaluation_context)
             .await
             .value
@@ -47,7 +44,9 @@ impl Client {
         default_value: i64,
         evaluation_context: Option<&EvaluationContext>,
     ) -> i64 {
-        self.provider
+        self.get_provider()
+            .await
+            .get()
             .resolve_int_value(flag_key, default_value, evaluation_context)
             .await
             .value
@@ -59,7 +58,9 @@ impl Client {
         default_value: f64,
         evaluation_context: Option<&EvaluationContext>,
     ) -> f64 {
-        self.provider
+        self.get_provider()
+            .await
+            .get()
             .resolve_float_value(flag_key, default_value, evaluation_context)
             .await
             .value
@@ -71,7 +72,9 @@ impl Client {
         default_value: &str,
         evaluation_context: Option<&EvaluationContext>,
     ) -> String {
-        self.provider
+        self.get_provider()
+            .await
+            .get()
             .resolve_string_value(flag_key, default_value, evaluation_context)
             .await
             .value
@@ -87,7 +90,9 @@ impl Client {
         T: From<StructValue>,
     {
         let result = self
-            .provider
+            .get_provider()
+            .await
+            .get()
             .resolve_struct_value(flag_key, StructValue::default(), evaluation_context)
             .await;
 
@@ -96,5 +101,9 @@ impl Client {
         } else {
             result.value.into()
         }
+    }
+
+    async fn get_provider(&self) -> FeatureProviderWrapper {
+        self.providers.get(&self.metadata.name).await
     }
 }

--- a/src/api/global_evaluation_context.rs
+++ b/src/api/global_evaluation_context.rs
@@ -5,7 +5,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use crate::EvaluationContext;
 
 #[derive(Clone, Default)]
-pub struct GlobalEvaluationContext(pub Arc<RwLock<EvaluationContext>>);
+pub struct GlobalEvaluationContext(Arc<RwLock<EvaluationContext>>);
 
 impl GlobalEvaluationContext {
     pub async fn get(&self) -> RwLockReadGuard<EvaluationContext> {

--- a/src/api/global_evaluation_context.rs
+++ b/src/api/global_evaluation_context.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::EvaluationContext;
+
+#[derive(Clone, Default)]
+pub struct GlobalEvaluationContext(pub Arc<RwLock<EvaluationContext>>);
+
+impl GlobalEvaluationContext {
+    pub async fn get(&self) -> RwLockReadGuard<EvaluationContext> {
+        self.0.read().await
+    }
+
+    pub async fn get_mut(&self) -> RwLockWriteGuard<EvaluationContext> {
+        self.0.write().await
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,3 +5,5 @@ mod client;
 pub use client::Client;
 
 mod provider_registry;
+
+mod global_evaluation_context;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,5 @@
 mod api;
-pub use api::*;
+pub use api::OpenFeature;
 
 mod client;
 pub use client::Client;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,3 +3,5 @@ pub use api::*;
 
 mod client;
 pub use client::Client;
+
+mod provider_registry;

--- a/src/api/provider_registry.rs
+++ b/src/api/provider_registry.rs
@@ -57,6 +57,10 @@ impl ProviderRegistry {
             .get(name)
             .map(|provider| provider.clone())
     }
+
+    pub async fn clear(&self) {
+        self.0.write().await.clear();
+    }
 }
 
 impl Default for ProviderRegistry {

--- a/src/api/provider_registry.rs
+++ b/src/api/provider_registry.rs
@@ -1,0 +1,85 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::{
+    provider::{FeatureProvider, NoOpProvider},
+    EvaluationContext,
+};
+
+// ====================================================================
+//  ProviderRegistry
+// ====================================================================
+
+#[derive(Clone)]
+pub struct ProviderRegistry(Arc<RwLock<HashMap<String, FeatureProviderWrapper>>>);
+
+impl ProviderRegistry {
+    pub async fn set_default<T: FeatureProvider>(&self, mut provider: T) {
+        let mut map = self.0.write().await;
+        map.remove("");
+
+        provider.initialize(EvaluationContext::default()).await;
+
+        map.insert(String::default(), FeatureProviderWrapper::new(provider));
+    }
+
+    pub async fn set_named<T: FeatureProvider>(&self, name: &str, mut provider: T) {
+        // Drop the already registered provider if any.
+        if let Some(provider) = self.get_named(name).await {
+            self.0.write().await.remove(name);
+        }
+
+        provider.initialize(EvaluationContext::default()).await;
+
+        self.0
+            .write()
+            .await
+            .insert(name.to_string(), FeatureProviderWrapper::new(provider));
+    }
+
+    pub async fn get(&self, name: &str) -> FeatureProviderWrapper {
+        match self.get_named(name).await {
+            Some(provider) => provider,
+            None => self.get_default().await,
+        }
+    }
+
+    pub async fn get_default(&self) -> FeatureProviderWrapper {
+        self.0.read().await.get("").unwrap().clone()
+    }
+
+    pub async fn get_named(&self, name: &str) -> Option<FeatureProviderWrapper> {
+        self.0
+            .read()
+            .await
+            .get(name)
+            .map(|provider| provider.clone())
+    }
+}
+
+impl Default for ProviderRegistry {
+    fn default() -> Self {
+        let mut providers: HashMap<String, FeatureProviderWrapper> = HashMap::new();
+        providers.insert(
+            String::default(),
+            FeatureProviderWrapper::new(NoOpProvider::new()),
+        );
+
+        Self(Arc::new(RwLock::new(providers)))
+    }
+}
+
+#[derive(Clone)]
+pub struct FeatureProviderWrapper(Arc<dyn FeatureProvider>);
+
+impl FeatureProviderWrapper {
+    pub fn new(provider: impl FeatureProvider) -> Self {
+        Self(Arc::new(provider))
+    }
+
+    pub fn get(&self) -> Arc<dyn FeatureProvider> {
+        self.0.clone()
+    }
+}

--- a/src/api/provider_registry.rs
+++ b/src/api/provider_registry.rs
@@ -27,7 +27,7 @@ impl ProviderRegistry {
 
     pub async fn set_named<T: FeatureProvider>(&self, name: &str, mut provider: T) {
         // Drop the already registered provider if any.
-        if let Some(provider) = self.get_named(name).await {
+        if let Some(_) = self.get_named(name).await {
             self.0.write().await.remove(name);
         }
 

--- a/src/evaluation/context.rs
+++ b/src/evaluation/context.rs
@@ -13,7 +13,7 @@ use crate::EvaluationContextFieldValue;
 /// define rules that return a specific value based on the user's email address, locale, or the
 /// time of day. The context provides this information. The context can be optionally provided at
 /// evaluation, and mutated in before hooks.
-#[derive(Clone, TypedBuilder, Default)]
+#[derive(Clone, TypedBuilder, Default, PartialEq, Debug)]
 pub struct EvaluationContext {
     /// The targeting key uniquely identifies the subject (end-user, or client service) of a flag
     /// evaluation. Providers may require this field for fractional flag evaluation, rules, or
@@ -43,4 +43,92 @@ impl EvaluationContext {
     ) {
         self.custom_fields.insert(key.into(), value.into());
     }
+
+    pub fn merge_missing(&mut self, other: &Self) {
+        if self.targeting_key.is_none() {
+            if let Some(targeting_key) = &other.targeting_key {
+                self.targeting_key = Some(targeting_key.clone());
+            }
+        }
+
+        other.custom_fields.iter().for_each(|(key, value)| {
+            if !self.custom_fields.contains_key(key) {
+                self.custom_fields.insert(key.clone(), value.clone());
+            }
+        });
+    }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_missig_given_empty() {
+        let mut context = EvaluationContext::builder()
+            .targeting_key("Targeting Key")
+            .build()
+            .with_custom_field("Some", "Value");
+
+        let expected = context.clone();
+
+        context.merge_missing(&EvaluationContext::default());
+
+        assert_eq!(context, expected);
+    }
+
+    #[test]
+    fn merge_missing_given_targeting_key() {
+        let mut context = EvaluationContext::builder()
+            .targeting_key("Targeting Key")
+            .build();
+
+        let expected = context.clone();
+
+        context.merge_missing(
+            &EvaluationContext::builder()
+                .targeting_key("Another Key")
+                .build(),
+        );
+
+        assert_eq!(context, expected);
+    }
+
+    #[test]
+    fn merge_missing_given_custom_fields() {
+        let mut context = EvaluationContext::builder()
+            .targeting_key("Targeting Key")
+            .build()
+            .with_custom_field("Key", "Value");
+
+        context.merge_missing(
+            &EvaluationContext::default()
+                .with_custom_field("Key", "Another Value")
+                .with_custom_field("Another Key", "Value"),
+        );
+
+        assert_eq!(
+            context,
+            EvaluationContext::builder()
+                .targeting_key("Targeting Key")
+                .build()
+                .with_custom_field("Key", "Value")
+                .with_custom_field("Another Key", "Value")
+        )
+    }
+
+    #[test]
+    fn merge_missing_given_full() {
+        let mut context = EvaluationContext::default();
+
+        let other = EvaluationContext::builder()
+            .targeting_key("Targeting Key")
+            .build()
+            .with_custom_field("Key", "Value");
+
+        context.merge_missing(&other);
+
+        assert_eq!(context, other);
+    }
+}
+

--- a/src/evaluation/details.rs
+++ b/src/evaluation/details.rs
@@ -64,8 +64,8 @@ impl ToString for EvaluationReason {
 /// Struct representing error
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct EvaluationError {
-    code: EvaluationErrorCode,
-    message: Option<String>,
+    pub code: EvaluationErrorCode,
+    pub message: Option<String>,
 }
 
 /// An enumerated error code represented idiomatically in the implementation language.

--- a/src/evaluation/field_value.rs
+++ b/src/evaluation/field_value.rs
@@ -99,6 +99,32 @@ impl From<OffsetDateTime> for EvaluationContextFieldValue {
     }
 }
 
+impl PartialEq for EvaluationContextFieldValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (EvaluationContextFieldValue::Bool(left), EvaluationContextFieldValue::Bool(right)) => {
+                left == right
+            }
+            (EvaluationContextFieldValue::Int(left), EvaluationContextFieldValue::Int(right)) => {
+                left == right
+            }
+            (
+                EvaluationContextFieldValue::Float(left),
+                EvaluationContextFieldValue::Float(right),
+            ) => left == right,
+            (
+                EvaluationContextFieldValue::String(left),
+                EvaluationContextFieldValue::String(right),
+            ) => left == right,
+            (
+                EvaluationContextFieldValue::DateTime(left),
+                EvaluationContextFieldValue::DateTime(right),
+            ) => left == right,
+            (_, _) => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,7 +154,7 @@ mod tests {
             assert_eq!(true, *value);
         } else {
             panic!()
-        };
+        }
 
         // Assert int.
         if let EvaluationContextFieldValue::Int(value) = context.custom_fields.get("Int").unwrap() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod api;
-pub use api::*;
+pub use api::{Client, OpenFeature};
 
 mod evaluation;
 pub use evaluation::*;

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -1,5 +1,3 @@
-use std::{any::Any, borrow::Cow, sync::Arc};
-
 use async_trait::async_trait;
 use typed_builder::TypedBuilder;
 
@@ -23,8 +21,8 @@ use mockall::{automock, predicate::*};
 /// vendor SDK, embed an REST client, or read flags from a local file.
 ///
 /// See the [spec](https://openfeature.dev/specification/sections/providers).
-#[async_trait]
 #[cfg_attr(test, automock)]
+#[async_trait]
 pub trait FeatureProvider: Send + Sync + 'static {
     /// The provider MAY define an initialize function which accepts the global evaluation
     /// context as an argument and performs initialization logic relevant to the provider.
@@ -36,6 +34,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
     /// abnormally.
     /// * The provider SHOULD indicate an error if flag resolution is attempted before the provider
     /// is ready.
+    #[allow(unused_variables)]
     async fn initialize(&mut self, context: EvaluationContext) {}
 
     /// The provider MAY define a status field/accessor which indicates the readiness of the
@@ -55,7 +54,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         &self,
         flag_key: &str,
         default_value: bool,
-        evaluation_context: Option<&EvaluationContext>,
+        evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<bool>;
 
     /// Resolve given `flag_key` as an i64 value.
@@ -63,7 +62,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         &self,
         flag_key: &str,
         default_value: i64,
-        evaluation_context: Option<&EvaluationContext>,
+        evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<i64>;
 
     /// Resolve given `flag_key` as a f64 value.
@@ -71,7 +70,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         &self,
         flag_key: &str,
         default_value: f64,
-        evaluation_context: Option<&EvaluationContext>,
+        evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<f64>;
 
     /// Resolve given `flag_key` as a string value.
@@ -79,7 +78,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         &self,
         flag_key: &str,
         default_value: &str,
-        evaluation_context: Option<&EvaluationContext>,
+        evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<String>;
 
     /// Resolve given `flag_key` as a struct value.
@@ -87,7 +86,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         &self,
         flag_key: &str,
         default_value: StructValue,
-        evaluation_context: Option<&EvaluationContext>,
+        evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<StructValue>;
 }
 

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -47,7 +47,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
 
     /// The provider interface MUST define a metadata member or accessor, containing a name field
     /// or accessor of type string, which identifies the provider implementation.
-    fn metadata(&self) -> ProviderMetadata;
+    fn metadata(&self) -> &ProviderMetadata;
 
     /// Resolve given `flag_key` as a bool value.
     async fn resolve_bool_value(

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -7,6 +7,9 @@ use crate::{EvaluationContext, StructValue};
 
 use super::ResolutionDetails;
 
+#[cfg(test)]
+use mockall::{automock, predicate::*};
+
 /// This trait defines interfaces that Provider Authors can use to abstract a particular flag
 /// management system, thus enabling the use of the evaluation API by Application Authors.
 ///
@@ -21,6 +24,7 @@ use super::ResolutionDetails;
 ///
 /// See the [spec](https://openfeature.dev/specification/sections/providers).
 #[async_trait]
+#[cfg_attr(test, automock)]
 pub trait FeatureProvider: Send + Sync + 'static {
     /// The provider MAY define an initialize function which accepts the global evaluation
     /// context as an argument and performs initialization logic relevant to the provider.
@@ -34,10 +38,6 @@ pub trait FeatureProvider: Send + Sync + 'static {
     /// is ready.
     async fn initialize(&mut self, context: EvaluationContext) {}
 
-    /// The provider MAY define a shutdown function to perform whatever cleanup is necessary for
-    /// the implementation.
-    async fn shutdown(&mut self) {}
-
     /// The provider MAY define a status field/accessor which indicates the readiness of the
     /// provider, with possible values NOT_READY, READY, or ERROR.
     ///
@@ -48,9 +48,9 @@ pub trait FeatureProvider: Send + Sync + 'static {
 
     /// The provider interface MUST define a metadata member or accessor, containing a name field
     /// or accessor of type string, which identifies the provider implementation.
-    fn metadata(&self) -> &ProviderMetadata;
+    fn metadata(&self) -> ProviderMetadata;
 
-    /// Resolve given [`flag_key`] as a bool value.
+    /// Resolve given `flag_key` as a bool value.
     async fn resolve_bool_value(
         &self,
         flag_key: &str,
@@ -58,7 +58,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         evaluation_context: Option<&EvaluationContext>,
     ) -> ResolutionDetails<bool>;
 
-    /// Resolve given [`flag_key`] as an i64 value.
+    /// Resolve given `flag_key` as an i64 value.
     async fn resolve_int_value(
         &self,
         flag_key: &str,
@@ -66,7 +66,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         evaluation_context: Option<&EvaluationContext>,
     ) -> ResolutionDetails<i64>;
 
-    /// Resolve given [`flag_key`] as a f64 value.
+    /// Resolve given `flag_key` as a f64 value.
     async fn resolve_float_value(
         &self,
         flag_key: &str,
@@ -74,7 +74,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         evaluation_context: Option<&EvaluationContext>,
     ) -> ResolutionDetails<f64>;
 
-    /// Resolve given [`flag_key`] as a string value.
+    /// Resolve given `flag_key` as a string value.
     async fn resolve_string_value(
         &self,
         flag_key: &str,
@@ -82,7 +82,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
         evaluation_context: Option<&EvaluationContext>,
     ) -> ResolutionDetails<String>;
 
-    /// Resolve given [`flag_key`] as a struct value.
+    /// Resolve given `flag_key` as a struct value.
     async fn resolve_struct_value(
         &self,
         flag_key: &str,

--- a/src/provider/fixed_value_provider.rs
+++ b/src/provider/fixed_value_provider.rs
@@ -57,7 +57,7 @@ impl FeatureProvider for FixedValueProvider {
         &self,
         _flag_key: &str,
         _default_value: bool,
-        _evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<bool> {
         ResolutionDetails::new(self.bool_value)
     }
@@ -66,7 +66,7 @@ impl FeatureProvider for FixedValueProvider {
         &self,
         _flag_key: &str,
         _default_value: i64,
-        _evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<i64> {
         ResolutionDetails::new(self.int_value)
     }
@@ -75,7 +75,7 @@ impl FeatureProvider for FixedValueProvider {
         &self,
         _flag_key: &str,
         _default_value: f64,
-        _evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<f64> {
         ResolutionDetails::new(self.float_value)
     }
@@ -84,7 +84,7 @@ impl FeatureProvider for FixedValueProvider {
         &self,
         _flag_key: &str,
         _default_value: &str,
-        _evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<String> {
         ResolutionDetails::new(self.string_value.clone())
     }
@@ -93,7 +93,7 @@ impl FeatureProvider for FixedValueProvider {
         &self,
         _flag_key: &str,
         _default_value: StructValue,
-        _evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<StructValue> {
         ResolutionDetails::new((*self.struct_value).clone())
     }

--- a/src/provider/fixed_value_provider.rs
+++ b/src/provider/fixed_value_provider.rs
@@ -49,8 +49,8 @@ impl Default for FixedValueProvider {
 
 #[async_trait]
 impl FeatureProvider for FixedValueProvider {
-    fn metadata(&self) -> ProviderMetadata {
-        self.metadata.clone()
+    fn metadata(&self) -> &ProviderMetadata {
+        &self.metadata
     }
 
     async fn resolve_bool_value(

--- a/src/provider/fixed_value_provider.rs
+++ b/src/provider/fixed_value_provider.rs
@@ -49,8 +49,8 @@ impl Default for FixedValueProvider {
 
 #[async_trait]
 impl FeatureProvider for FixedValueProvider {
-    fn metadata(&self) -> &ProviderMetadata {
-        &self.metadata
+    fn metadata(&self) -> ProviderMetadata {
+        self.metadata.clone()
     }
 
     async fn resolve_bool_value(

--- a/src/provider/no_op_provider.rs
+++ b/src/provider/no_op_provider.rs
@@ -30,8 +30,8 @@ impl Default for NoOpProvider {
 
 #[async_trait]
 impl FeatureProvider for NoOpProvider {
-    fn metadata(&self) -> ProviderMetadata {
-        self.metadata.clone()
+    fn metadata(&self) -> &ProviderMetadata {
+        &self.metadata
     }
 
     async fn resolve_bool_value(

--- a/src/provider/no_op_provider.rs
+++ b/src/provider/no_op_provider.rs
@@ -6,7 +6,7 @@ use super::{FeatureProvider, ProviderMetadata, ResolutionDetails};
 
 const PROVIDER_NAME: &'static str = "No Operation";
 
-/// The default provider that simply returns given default value during evaluation.
+/// The default provider that simply returns given default value during _evaluation.
 #[derive(Debug)]
 pub struct NoOpProvider {
     metadata: ProviderMetadata,
@@ -36,45 +36,45 @@ impl FeatureProvider for NoOpProvider {
 
     async fn resolve_bool_value(
         &self,
-        flag_key: &str,
+        _flag_key: &str,
         default_value: bool,
-        evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<bool> {
         ResolutionDetails::new(default_value)
     }
 
     async fn resolve_int_value(
         &self,
-        flag_key: &str,
+        _flag_key: &str,
         default_value: i64,
-        evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<i64> {
         ResolutionDetails::new(default_value)
     }
 
     async fn resolve_float_value(
         &self,
-        flag_key: &str,
+        _flag_key: &str,
         default_value: f64,
-        evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<f64> {
         ResolutionDetails::new(default_value)
     }
 
     async fn resolve_string_value(
         &self,
-        flag_key: &str,
+        _flag_key: &str,
         default_value: &str,
-        evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<String> {
         ResolutionDetails::new(default_value)
     }
 
     async fn resolve_struct_value(
         &self,
-        flag_key: &str,
+        _flag_key: &str,
         default_value: StructValue,
-        evaluation_context: Option<&EvaluationContext>,
+        _evaluation_context: &EvaluationContext,
     ) -> ResolutionDetails<StructValue> {
         ResolutionDetails::new(default_value)
     }

--- a/src/provider/no_op_provider.rs
+++ b/src/provider/no_op_provider.rs
@@ -30,8 +30,8 @@ impl Default for NoOpProvider {
 
 #[async_trait]
 impl FeatureProvider for NoOpProvider {
-    fn metadata(&self) -> &ProviderMetadata {
-        &self.metadata
+    fn metadata(&self) -> ProviderMetadata {
+        self.metadata.clone()
     }
 
     async fn resolve_bool_value(


### PR DESCRIPTION
## About

* Implement binding a provider to a given name.
* Implement binding named provider to corresponding named client. Client will pick up new provider after setting a new one.
* Implement evaluation context merge. 
* Add more tests.

### Notes

The type of `FeatureProvider` looks a bit scary. `Arc<RwLock<T>>` is used because the inner `T` needs to be both read and written, while the ownership is shared. Rust does not allow mutation for shared ownership stuff (`Arc<T>`).

If you can come up with a better idea or have any ideas, feel free to leave a comment. :-)

### Follow-up Tasks

After detailed evaluation is done, the only remaining missing features would be hooks and events.
I think that will be a good time to publish a 0.1 version.
My estimation is that it will take 1-2 more PRs to achieve that milestone.

* Implement detailed flag evaluation.
* Provide comprehensive tests for exiting features.
* Enhance README.

### How to test

By UT.
