### PR TITLE
feat: use TryFrom instead of custom trait for StructValue conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ async fn extended_example() {
 
 #### Getting a Struct from a Provider
 
-It is possible to extract a struct from the provider. Internally, this SDK defines a type `StructValue` to store any structure value. The `client.get_struct_value()` functions takes a type parameter `T`. It will try to parse `StructValue` resolved by the provider to `T`, as long as `T` implements trait `FromStructValue`.
+It is possible to extract a struct from the provider. Internally, this SDK defines a type `StructValue` to store any structure value. The `client.get_struct_value()` functions takes a type parameter `T`. It will try to parse `StructValue` resolved by the provider to `T`, as long as `T` implements trait `TryFrom<StructValue>`.
 
 You can pass in a type that satisfies this trait bound. When the conversion fails, it returns an `Err` with `EvaluationReason::TypeMismatch`.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,7 +2,7 @@ mod api;
 pub use api::OpenFeature;
 
 mod client;
-pub use client::{Client, ClientMetadata, FromStructValue};
+pub use client::{Client, ClientMetadata};
 
 mod provider_registry;
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Use `TryFrom<StructValue>` to support conversion between `StructValue` and custom types, instead of the custom trait `FromStructValue`.

### Related Issues

N/A

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

