### PR TITLE
feat!: re-design No-op Provider

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
+      
     - name: Check formats
       run: cargo fmt --check
+
+    - name: Check code quality
+      run: cargo clippy -- -D warnings
+
+    - name: Build
+      run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ typed-builder = "0.18.0"
 spec = { path = "spec" }
 
 [features]
-default = [ "mockall" ]
-mockall = [ "dep:mockall" ]
+default = [ "test-util" ]
+test-util = [ "dep:mockall" ]
 serde_json = [ "dep:serde_json" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 async-trait = "0.1.77"
 lazy_static = "1.4.0"
+mockall = { version = "0.12.1", optional = true }
 serde_json = { version = "1.0.111", optional = true }
 time = "0.3.31"
 tokio = { version = "1.35.1", features = [ "full" ] }
@@ -27,4 +28,6 @@ typed-builder = "0.18.0"
 spec = { path = "spec" }
 
 [features]
-serde_json = ["dep:serde_json"]
+default = [ "mockall" ]
+mockall = [ "dep:mockall" ]
+serde_json = [ "dep:serde_json" ]

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -104,7 +104,7 @@ mod tests {
     use super::*;
     use crate::{
         provider::{MockFeatureProvider, NoOpProvider, ResolutionDetails},
-        EvaluationContextFieldValue, EvaluationReason,
+        EvaluationContextFieldValue,
     };
     use mockall::predicate;
     use spec::spec;
@@ -408,11 +408,11 @@ mod tests {
     struct MyStruct {}
 
     #[tokio::test]
-    async fn example() {
+    async fn extended_example() {
         // Acquire an OpenFeature API instance.
-        // Note the `await` call here because asynchronous lock is used to guarantee thread safety.
         let mut api = OpenFeature::singleton_mut().await;
 
+        // Set the default (unnamed) provider.
         api.set_provider(NoOpProvider::default()).await;
 
         // Create an unnamed client.
@@ -420,8 +420,6 @@ mod tests {
 
         // Create an evaluation context.
         // It supports types mentioned in the specification.
-        //
-        // You have multiple ways to add a custom field.
         let evaluation_context = EvaluationContext::default()
             .with_targeting_key("Targeting")
             .with_custom_field("bool_key", true)
@@ -439,39 +437,18 @@ mod tests {
                 EvaluationContextFieldValue::new_struct(MyStruct::default()),
             );
 
-        // This function returns a `Result`. You can process it with functions provided by std.
+        // This function returns a `Result`.
+        // You can process it with functions provided by std.
         let is_feature_enabled = client
             .get_bool_value("SomeFlagEnabled", Some(&evaluation_context), None)
             .await
             .unwrap_or(false);
 
         if is_feature_enabled {
-            // Do something.
-        }
-
-        // Let's get evaluation details.
-        let result = client
-            .get_int_details(
-                "key",
-                Some(&EvaluationContext::default().with_custom_field("some_key", "some_value")),
-                None,
-            )
-            .await;
-
-        match result {
-            Ok(details) => {
-                assert_eq!(details.value, 100);
-                assert_eq!(details.reason, Some(EvaluationReason::Static));
-                assert_eq!(details.variant, Some("Static".to_string()));
-                assert_eq!(details.flag_metadata.values.iter().count(), 2);
-            }
-            Err(error) => {
-                println!(
-                    "Error: {}\nMessage: {:?}\n",
-                    error.code.to_string(),
-                    error.message
-                );
-            }
+            // Let's get evaluation details.
+            let _result = client
+                .get_int_details("key", Some(&evaluation_context), None)
+                .await;
         }
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -303,7 +303,6 @@ impl<T> ResolutionDetails<T> {
 
 #[cfg(test)]
 mod tests {
-    //use std::sync::Arc;
 
     use spec::spec;
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -303,7 +303,7 @@ impl<T> ResolutionDetails<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    //use std::sync::Arc;
 
     use spec::spec;
 
@@ -311,8 +311,8 @@ mod tests {
         api::{
             global_evaluation_context::GlobalEvaluationContext, provider_registry::ProviderRegistry,
         },
-        provider::NoOpProvider,
-        Client, EvaluationReason, FlagMetadata, StructValue,
+        provider::{FeatureProvider, MockFeatureProvider, ResolutionDetails},
+        Client, EvaluationReason, FlagMetadata, StructValue, Value,
     };
 
     #[spec(
@@ -356,35 +356,63 @@ mod tests {
         number = "1.3.1.1",
         text = "The client MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters flag key (string, required), default value (boolean | number | string | structure, required), evaluation context (optional), and evaluation options (optional), which returns the flag value."
     )]
+    #[spec(
+        number = "1.3.3.1",
+        text = "The client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms."
+    )]
     #[tokio::test]
     async fn get_value() {
         // Test bool.
-        let client = create_client(NoOpProvider::builder().bool_value(true).build()).await;
+        let mut provider = MockFeatureProvider::new();
+        provider.expect_initialize().returning(|_| {});
+
+        provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        provider
+            .expect_resolve_int_value()
+            .return_const(Ok(ResolutionDetails::new(123)));
+
+        provider
+            .expect_resolve_float_value()
+            .return_const(Ok(ResolutionDetails::new(12.34)));
+
+        provider
+            .expect_resolve_string_value()
+            .return_const(Ok(ResolutionDetails::new("Hello")));
+
+        provider
+            .expect_resolve_struct_value()
+            .return_const(Ok(ResolutionDetails::new(
+                StructValue::default()
+                    .with_field("id", 100)
+                    .with_field("name", "Alex"),
+            )));
+
+        let client = create_client(provider).await;
 
         assert_eq!(
             client.get_bool_value("key", None, None).await.unwrap(),
             true
         );
 
-        // Test string.
-        let client = create_client(NoOpProvider::builder().string_value("result").build()).await;
+        assert_eq!(client.get_int_value("key", None, None).await.unwrap(), 123);
+
+        assert_eq!(
+            client.get_float_value("key", None, None).await.unwrap(),
+            12.34
+        );
 
         assert_eq!(
             client.get_string_value("", None, None).await.unwrap(),
-            "result"
+            "Hello"
         );
 
-        // Test struct.
-        let client = create_client(
-            NoOpProvider::builder()
-                .struct_value(Arc::new(
-                    StructValue::default()
-                        .with_field("id", 100)
-                        .with_field("name", "Alex"),
-                ))
-                .build(),
-        )
-        .await;
+        println!(
+            "Result: {:?}",
+            client.get_struct_value::<Value>("", None, None).await
+        );
 
         assert_eq!(
             client
@@ -396,21 +424,6 @@ mod tests {
                 name: "Alex".to_string()
             }
         );
-    }
-
-    #[spec(
-        number = "1.3.3.1",
-        text = "The client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms."
-    )]
-    #[tokio::test]
-    async fn get_numeric_value() {
-        // Test int.
-        let client = create_client(NoOpProvider::builder().int_value(200).build()).await;
-        assert_eq!(client.get_int_value("key", None, None).await.unwrap(), 200);
-
-        // Test float.
-        let client = create_client(NoOpProvider::builder().float_value(5.0).build()).await;
-        assert_eq!(client.get_float_value("", None, None).await.unwrap(), 5.0);
     }
 
     #[spec(
@@ -450,24 +463,24 @@ mod tests {
     )]
     #[tokio::test]
     async fn get_details() {
-        let provider = NoOpProvider::builder().int_value(100).build();
+        let mut provider = MockFeatureProvider::new();
+        provider.expect_initialize().returning(|_| {});
+        provider
+            .expect_resolve_int_value()
+            .return_const(Ok(ResolutionDetails::builder()
+                .value(123)
+                .variant("Static")
+                .reason(EvaluationReason::Static)
+                .build()));
+
         let client = create_client(provider).await;
 
         let result = client.get_int_details("key", None, None).await.unwrap();
 
-        assert_eq!(result.value, 100);
+        assert_eq!(result.value, 123);
         assert_eq!(result.flag_key, "key");
         assert_eq!(result.reason, Some(EvaluationReason::Static));
         assert_eq!(result.variant, Some("Static".to_string()));
-
-        assert_eq!(
-            client
-                .get_bool_details("another_key", None, None)
-                .await
-                .unwrap()
-                .reason,
-            Some(EvaluationReason::Default)
-        );
     }
 
     #[spec(
@@ -502,22 +515,23 @@ mod tests {
     )]
     #[tokio::test]
     async fn get_details_flag_metadata() {
-        let client = create_default_client();
+        let mut provider = MockFeatureProvider::new();
+        provider.expect_initialize().returning(|_| {});
+        provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::builder()
+                .value(true)
+                .flag_metadata(FlagMetadata::default().with_value("Type", "Bool"))
+                .build()));
+
+        let client = create_client(provider).await;
 
         let result = client.get_bool_details("", None, None).await.unwrap();
+
         assert_eq!(
             *result.flag_metadata.values.get("Type").unwrap(),
             "Bool".into()
         );
-
-        assert_eq!(
-            client
-                .get_struct_details::<Student>("", None, None)
-                .await
-                .unwrap()
-                .flag_metadata,
-            FlagMetadata::default()
-        )
     }
 
     #[spec(
@@ -539,7 +553,7 @@ mod tests {
         )
     }
 
-    async fn create_client(provider: NoOpProvider) -> Client {
+    async fn create_client(provider: impl FeatureProvider) -> Client {
         let provider_registry = ProviderRegistry::default();
         provider_registry.set_named("custom", provider).await;
 

--- a/src/evaluation/context.rs
+++ b/src/evaluation/context.rs
@@ -25,7 +25,7 @@ pub struct EvaluationContext {
 }
 
 impl EvaluationContext {
-    /// Create a new [`EvaluationContext`] with given targeting key.
+    /// Set the `targeting_key` of the evaluation context.
     #[must_use]
     pub fn with_targeting_key(mut self, targeting_key: impl Into<String>) -> Self {
         self.targeting_key = Some(targeting_key.into());

--- a/src/evaluation/context_field_value.rs
+++ b/src/evaluation/context_field_value.rs
@@ -221,9 +221,8 @@ mod tests {
     fn evaluation_context_custom_fields() {
         let now = OffsetDateTime::now_utc();
 
-        let context = EvaluationContext::builder()
-            .targeting_key("Some Key")
-            .build()
+        let context = EvaluationContext::default()
+            .with_targeting_key("Some Key")
             .with_custom_field("Bool", false)
             .with_custom_field("Bool", EvaluationContextFieldValue::Bool(true))
             .with_custom_field("Int", 42)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@
 //! Check its README for examples.
 
 #![warn(missing_docs)]
-#![deny(warnings)]
-#![deny(clippy::pedantic)]
+#![warn(clippy::pedantic)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::implicit_hasher)]
 #![allow(clippy::manual_let_else)]

--- a/src/provider/details.rs
+++ b/src/provider/details.rs
@@ -13,7 +13,7 @@ pub struct ResolutionDetails<T> {
     /// In cases of normal execution, the provider SHOULD populate the resolution details
     /// structure's variant field with a string identifier corresponding to the returned flag
     /// value.
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(into, strip_option))]
     pub variant: Option<String>,
 
     /// The provider SHOULD populate the resolution details structure's reason field with "STATIC",
@@ -40,7 +40,7 @@ impl<T: Default> Default for ResolutionDetails<T> {
 
 impl<T> ResolutionDetails<T> {
     /// Create an instance given value.
-    pub fn new<V: Into<T>>(value: V) -> Self {
+    pub fn new(value: impl Into<T>) -> Self {
         Self {
             value: value.into(),
             variant: None,

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use typed_builder::TypedBuilder;
 
 use crate::{EvaluationContext, EvaluationResult, StructValue};
 
@@ -22,6 +21,7 @@ use super::ResolutionDetails;
 /// vendor SDK, embed an REST client, or read flags from a local file.
 ///
 /// See the [spec](https://openfeature.dev/specification/sections/providers).
+#[cfg_attr(feature = "mockall", mockall::automock)]
 #[async_trait]
 pub trait FeatureProvider: Send + Sync + 'static {
     /// The provider MAY define an initialize function which accepts the global evaluation
@@ -90,10 +90,9 @@ pub trait FeatureProvider: Send + Sync + 'static {
 // ============================================================
 
 /// The metadata of a feature provider.
-#[derive(Clone, TypedBuilder, Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ProviderMetadata {
     /// The name of provider.
-    #[builder(setter(into))]
     pub name: String,
 }
 

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -21,7 +21,7 @@ use super::ResolutionDetails;
 /// vendor SDK, embed an REST client, or read flags from a local file.
 ///
 /// See the [spec](https://openfeature.dev/specification/sections/providers).
-#[cfg_attr(feature = "mockall", mockall::automock)]
+#[cfg_attr(feature = "test-util", mockall::automock)]
 #[async_trait]
 pub trait FeatureProvider: Send + Sync + 'static {
     /// The provider MAY define an initialize function which accepts the global evaluation

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,7 +4,9 @@ pub use details::ResolutionDetails;
 
 /// Feature provider trait.
 mod feature_provider;
-pub use feature_provider::{FeatureProvider, ProviderMetadata, ProviderStatus};
+pub use feature_provider::{
+    FeatureProvider, MockFeatureProvider, ProviderMetadata, ProviderStatus,
+};
 
 /// The default no-op provider.
 mod no_op_provider;

--- a/src/provider/no_op_provider.rs
+++ b/src/provider/no_op_provider.rs
@@ -1,14 +1,10 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
-use typed_builder::TypedBuilder;
 
 use crate::{
-    EvaluationContext, EvaluationContextFieldValue, EvaluationError, EvaluationReason,
-    FlagMetadata, FlagMetadataValue, StructValue,
+    EvaluationContext, EvaluationError, EvaluationErrorCode, EvaluationResult, StructValue,
 };
 
-use super::{FeatureProvider, ProviderMetadata, ResolutionDetails};
+use super::{FeatureProvider, ProviderMetadata, ProviderStatus, ResolutionDetails};
 
 // ============================================================
 //  NoOpProvider
@@ -16,86 +12,16 @@ use super::{FeatureProvider, ProviderMetadata, ResolutionDetails};
 
 /// The default provider that does nothing.
 ///
-/// By default, it returns the default value of each supported type. You can inject values (for
-/// testing purpose or simply providing some fixed value) when creating an instance.
-///
-/// Other tips:
-/// * It will return reason `Default` when the value equals to the default, `Static` otherwise.
-/// * It will return variant `"Default"` or `"Static"` respectively.
-/// * It will return flag metadata with key `"Type"` and a string value that corresponds to the
-///   real type, EXCEPT for `resolve_struct_value`.
-/// * It will return flag metadata with keys "TargetingKey" and value of targeting key extracted
-/// from the evaluation context, if the value is not `None`.
-/// * It will return flag metadata with keys/values extracted from the evaluation context, as long
-/// as the value is a bool, number or string.
-#[derive(TypedBuilder, Debug)]
+/// It always returns [`EvaluationError`] for all the given flag keys.
+#[derive(Debug)]
 pub struct NoOpProvider {
-    #[builder(default)]
     metadata: ProviderMetadata,
-
-    #[builder(default)]
-    bool_value: bool,
-
-    #[builder(default)]
-    int_value: i64,
-
-    #[builder(default)]
-    float_value: f64,
-
-    #[builder(default, setter(into))]
-    string_value: String,
-
-    #[builder(default, setter(into))]
-    struct_value: Arc<StructValue>,
-}
-
-impl NoOpProvider {
-    fn create_reason_variant(is_default: bool) -> (EvaluationReason, String) {
-        if is_default {
-            (EvaluationReason::Default, "Default".to_string())
-        } else {
-            (EvaluationReason::Static, "Static".to_string())
-        }
-    }
-
-    fn populate_evaluation_context_values(
-        flag_metadata: &mut FlagMetadata,
-        evaluation_context: &EvaluationContext,
-    ) {
-        if let Some(value) = &evaluation_context.targeting_key {
-            flag_metadata.add_value("TargetingKey", value.clone());
-        }
-
-        evaluation_context
-            .custom_fields
-            .iter()
-            .for_each(|(key, value)| match value {
-                EvaluationContextFieldValue::Bool(value) => {
-                    flag_metadata.add_value(key, FlagMetadataValue::Bool(*value));
-                }
-                EvaluationContextFieldValue::Int(value) => {
-                    flag_metadata.add_value(key, FlagMetadataValue::Int(*value));
-                }
-                EvaluationContextFieldValue::Float(value) => {
-                    flag_metadata.add_value(key, FlagMetadataValue::Float(*value));
-                }
-                EvaluationContextFieldValue::String(value) => {
-                    flag_metadata.add_value(key, FlagMetadataValue::String(value.clone()));
-                }
-                _ => (),
-            });
-    }
 }
 
 impl Default for NoOpProvider {
     fn default() -> Self {
         Self {
-            metadata: ProviderMetadata::new("No Operation - Default"),
-            bool_value: Default::default(),
-            int_value: Default::default(),
-            float_value: Default::default(),
-            string_value: String::default(),
-            struct_value: Arc::new(DummyStruct::default().into()),
+            metadata: ProviderMetadata::new("No-op Provider"),
         }
     }
 }
@@ -106,120 +32,56 @@ impl FeatureProvider for NoOpProvider {
         &self.metadata
     }
 
-    async fn initialize(&mut self, _evaluation_context: &EvaluationContext) {
-        self.metadata = ProviderMetadata::new("No Operation");
+    fn status(&self) -> ProviderStatus {
+        ProviderStatus::NotReady
     }
 
     async fn resolve_bool_value(
         &self,
         _flag_key: &str,
-        evaluation_context: &EvaluationContext,
-    ) -> Result<ResolutionDetails<bool>, EvaluationError> {
-        let (reason, variant) = Self::create_reason_variant(self.bool_value == bool::default());
-
-        let mut flag_metadata = FlagMetadata::default().with_value("Type", "Bool");
-        Self::populate_evaluation_context_values(&mut flag_metadata, evaluation_context);
-
-        Ok(ResolutionDetails::builder()
-            .value(self.bool_value)
-            .reason(reason)
-            .variant(variant)
-            .flag_metadata(flag_metadata)
-            .build())
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<bool>> {
+        just_error()
     }
 
     async fn resolve_int_value(
         &self,
         _flag_key: &str,
-        evaluation_context: &EvaluationContext,
-    ) -> Result<ResolutionDetails<i64>, EvaluationError> {
-        let (reason, variant) = Self::create_reason_variant(self.int_value == i64::default());
-
-        let mut flag_metadata = FlagMetadata::default().with_value("Type", "Int");
-        Self::populate_evaluation_context_values(&mut flag_metadata, evaluation_context);
-
-        Ok(ResolutionDetails::builder()
-            .value(self.int_value)
-            .reason(reason)
-            .variant(variant)
-            .flag_metadata(flag_metadata)
-            .build())
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<i64>> {
+        just_error()
     }
 
     async fn resolve_float_value(
         &self,
         _flag_key: &str,
-        evaluation_context: &EvaluationContext,
-    ) -> Result<ResolutionDetails<f64>, EvaluationError> {
-        let (reason, variant) =
-            Self::create_reason_variant((self.float_value - f64::default()).abs() < f64::EPSILON);
-
-        let mut flag_metadata = FlagMetadata::default().with_value("Type", "Float");
-        Self::populate_evaluation_context_values(&mut flag_metadata, evaluation_context);
-
-        Ok(ResolutionDetails::builder()
-            .value(self.float_value)
-            .reason(reason)
-            .variant(variant)
-            .flag_metadata(flag_metadata)
-            .build())
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<f64>> {
+        just_error()
     }
 
     async fn resolve_string_value(
         &self,
         _flag_key: &str,
-        evaluation_context: &EvaluationContext,
-    ) -> Result<ResolutionDetails<String>, EvaluationError> {
-        let (reason, variant) = Self::create_reason_variant(self.string_value == String::default());
-
-        let mut flag_metadata = FlagMetadata::default().with_value("Type", "String");
-        Self::populate_evaluation_context_values(&mut flag_metadata, evaluation_context);
-
-        Ok(ResolutionDetails::builder()
-            .value(self.string_value.clone())
-            .reason(reason)
-            .variant(variant)
-            .flag_metadata(flag_metadata)
-            .build())
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<String>> {
+        just_error()
     }
 
     async fn resolve_struct_value(
         &self,
         _flag_key: &str,
-        evaluation_context: &EvaluationContext,
+        _evaluation_context: &EvaluationContext,
     ) -> Result<ResolutionDetails<StructValue>, EvaluationError> {
-        let (reason, variant) = Self::create_reason_variant(self.struct_value == Arc::default());
-
-        let mut flag_metadata = FlagMetadata::default().with_value("Type", "Struct");
-        Self::populate_evaluation_context_values(&mut flag_metadata, evaluation_context);
-
-        Ok(ResolutionDetails::builder()
-            .value((*self.struct_value).clone())
-            .reason(reason)
-            .variant(variant)
-            .build())
+        just_error()
     }
 }
 
-// ============================================================
-//  DummyStruct
-// ============================================================
-
-#[derive(Clone, TypedBuilder, Default, Debug)]
-pub struct DummyStruct {
-    #[builder(default)]
-    id: i64,
-
-    #[builder(default, setter(into))]
-    name: String,
-}
-
-impl From<DummyStruct> for StructValue {
-    fn from(value: DummyStruct) -> Self {
-        StructValue::default()
-            .with_field("id", value.id)
-            .with_field("name", value.name)
-    }
+fn just_error<T>() -> EvaluationResult<T> {
+    Err(EvaluationError::builder()
+        .code(EvaluationErrorCode::ProviderNotReady)
+        .message("No-op provider is never ready")
+        .build())
 }
 
 // ============================================================
@@ -233,19 +95,6 @@ mod tests {
     use super::*;
     use crate::{provider::ProviderStatus, *};
 
-    #[test]
-    fn from_dummy_struct() {
-        let value = DummyStruct::builder().id(100).name("Alex").build();
-
-        let result: StructValue = value.into();
-
-        let expected = StructValue::default()
-            .with_field("id", 100)
-            .with_field("name", "Alex");
-
-        assert_eq!(expected, result);
-    }
-
     #[spec(
         number = "2.1.1",
         text = "The provider interface MUST define a metadata member or accessor, containing a name field or accessor of type string, which identifies the provider implementation."
@@ -254,7 +103,7 @@ mod tests {
     fn metadata_name() {
         let provider = NoOpProvider::default();
 
-        assert_eq!(provider.metadata().name, "No Operation - Default");
+        assert_eq!(provider.metadata().name, "No-op Provider");
     }
 
     #[spec(
@@ -291,82 +140,14 @@ mod tests {
     )]
     #[tokio::test]
     async fn resolve_value() {
-        let provider = NoOpProvider::builder()
-            .bool_value(true)
-            .int_value(100)
-            .string_value("Hello")
-            .struct_value(StructValue::default().with_field("Key", "Value"))
-            .build();
+        let provider = NoOpProvider::default();
+        let context = EvaluationContext::default();
 
-        // Check bool.
-        let result = provider
-            .resolve_bool_value("key", &EvaluationContext::default())
-            .await
-            .unwrap();
-
-        assert_eq!(result.value, true);
-        assert_eq!(result.reason, Some(EvaluationReason::Static));
-        assert_eq!(result.variant, Some("Static".to_string()));
-        assert_eq!(
-            result.flag_metadata,
-            Some(FlagMetadata::default().with_value("Type", "Bool"))
-        );
-
-        // Check int.
-        let result = provider
-            .resolve_int_value("key", &EvaluationContext::default())
-            .await
-            .unwrap();
-
-        assert_eq!(result.value, 100);
-        assert_eq!(result.reason, Some(EvaluationReason::Static));
-        assert_eq!(result.variant, Some("Static".to_string()));
-        assert_eq!(
-            result.flag_metadata,
-            Some(FlagMetadata::default().with_value("Type", "Int"))
-        );
-
-        // Check float.
-        let result = provider
-            .resolve_float_value("key", &EvaluationContext::default())
-            .await
-            .unwrap();
-
-        assert_eq!(result.value, 0.0);
-        assert_eq!(result.reason, Some(EvaluationReason::Default));
-        assert_eq!(result.variant, Some("Default".to_string()));
-        assert_eq!(
-            result.flag_metadata,
-            Some(FlagMetadata::default().with_value("Type", "Float"))
-        );
-
-        // Check string.
-        let result = provider
-            .resolve_string_value("key", &EvaluationContext::default())
-            .await
-            .unwrap();
-
-        assert_eq!(result.value, "Hello");
-        assert_eq!(result.reason, Some(EvaluationReason::Static));
-        assert_eq!(result.variant, Some("Static".to_string()));
-        assert_eq!(
-            result.flag_metadata,
-            Some(FlagMetadata::default().with_value("Type", "String"))
-        );
-
-        // Check struct.
-        let result = provider
-            .resolve_struct_value("key", &EvaluationContext::default())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            result.value,
-            StructValue::default().with_field("Key", "Value")
-        );
-        assert_eq!(result.reason, Some(EvaluationReason::Static));
-        assert_eq!(result.variant, Some("Static".to_string()));
-        assert_eq!(result.flag_metadata, None);
+        assert!(provider.resolve_bool_value("", &context).await.is_err());
+        assert!(provider.resolve_int_value("", &context).await.is_err());
+        assert!(provider.resolve_float_value("", &context).await.is_err());
+        assert!(provider.resolve_string_value("", &context).await.is_err());
+        assert!(provider.resolve_struct_value("", &context).await.is_err());
     }
 
     #[spec(
@@ -413,7 +194,7 @@ mod tests {
     #[tokio::test]
     async fn status() {
         let provider = NoOpProvider::default();
-        assert_eq!(provider.status(), ProviderStatus::Ready);
+        assert_eq!(provider.status(), ProviderStatus::NotReady);
     }
 
     #[spec(


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Change the implementation of `NoOpProvider`.
  - Always return `EvaluationError` with `ProviderNotReady` code.
  - Remove the ability to change its behaviors via constructors, `EvaluationContext` etc.
- Add `mockall` dependency to mock `FeatureProvider` trait.
- Adjust usage of `TypedBuilder`.
  - Remove typed builder for `EvaluationContext`.
    => Since every field is optional so just use `EvaluationContext::default().with_xx()` to make it more unified.
  - Remove typed builder usage for some simple types. => Less code bloat.
- Adjust release-please pipeline.
  - Check format before building it. => Shorten pipeline build time when format is wrong.
  - Move "deny warnings" from `lib.rs` to build pipeline. => Better DX.

### Related Issues

### Notes
<!-- any additional notes for this PR -->

The main purpose of changing `NoOpProvider` is to make it more compliant with the spec. The spec mentioned that:

> In the absence of a provider the evaluation API uses the "No-op provider", which simply returns the supplied default flag value.
The default NoOpProvider should return the supplied default flag value. 

In Rust we leverage the type system to model this, instead of letting user provide a default value upon function invocation. When the flag evaluation fails due to any reason, an EvaluationError is returned, and the caller can do something like `client.get_i32_value("flag_key", &context, None).unwrap_or(100)` to provide a default value.

Now the `NoOpProvider` returns the default value of each data type if not configured. This is actually incorrect because the `unwrap_or(..)` part will never be executed (because it is always `Ok`) and the caller cannot chain a default value then.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

