### PR TITLE
ci: split build job into build and lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,15 +21,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      
-    - name: Check formats
-      run: cargo fmt --check
 
-    - name: Check code quality
-      run: cargo clippy -- -D warnings
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
 
     - name: Build
       run: cargo build --verbose
 
     - name: Run tests
       run: cargo test --verbose
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check formats
+        run: cargo fmt --check
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check code quality
+        run: cargo clippy -- -D warnings


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- also added caching for the dependencies, which should improve the CI time even further
