### PR TITLE
chore: change Cargo.toml file to reference minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.77"
-lazy_static = "1.4.0"
-mockall = { version = "0.12.1", optional = true }
-serde_json = { version = "1.0.114", optional = true }
-time = "0.3.34"
-tokio = { version = "1.36.0", features = [ "full" ] }
-typed-builder = "0.18.1"
+async-trait = "0.1"
+lazy_static = "1.4"
+mockall = { version = "0.12", optional = true }
+serde_json = { version = "1.0", optional = true }
+time = "0.3"
+tokio = { version = "1.36", features = [ "full" ] }
+typed-builder = "0.18"
 
 [dev-dependencies]
 spec = { path = "spec" }


### PR DESCRIPTION
The existing Cargo.toml file references the dependencies using fix version, which led to too many chore PRs created by GitHub bot.

Hopefully this will reduce the maintenance burden.

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

