### PR TITLE
fix: specfinder was using an incorrect regex

### DIFF
--- a/spec_finder.py
+++ b/spec_finder.py
@@ -53,8 +53,11 @@ def main(refresh_spec=False, diff_output=False, limit_numbers=None):
             with open(F) as f:
                 data = ''.join(f.readlines())
 
-            for match in re.findall('#\[spec\((?P<innards>.*?)"\)\]', data.replace('\n', ''), re.MULTILINE | re.DOTALL):
+            # if "#[spec" in data:
+            #     import pdb; pdb.set_trace()
+            for match in re.findall('#\[spec\((?P<innards>.*?)\)\]', data.replace('\n', ''), re.MULTILINE | re.DOTALL):
                 number = re.findall('number\s*=\s*"(.*?)"', match)[0]
+
 
                 if number in missing:
                     missing.remove(number)


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
We had an erroneus quote in there which was breaking the regex

### How to test
`python3 spec_finder.py` and validate 1.1.1 isn't listed.