### PR TITLE
fix: reexport `async_trait::async_trait`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use evaluation::*;
 
 /// Feature provider related.
 pub mod provider;
+pub use async_trait::async_trait;
 
 /// Optional support for [`serde_json::Value`].
 #[cfg(feature = "serde_json")]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
To create a new provider using this library, we need to use the  `#[async_trait]` macro to impl traits.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
none

### How to test
<!-- if applicable, add testing instructions under this section -->

none