### PR TITLE
feat: Add hooks implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,16 @@ serde_json = { version = "1.0.116", optional = true }
 time = "0.3.36"
 tokio = { version = "1.40", features = ["full"] }
 typed-builder = "0.20.0"
-log = "0.4.14"
+
+log = { package = "log", version = "0.4", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11.5"
+structured-logger = "1.0.3"
 spec = { path = "spec" }
 
 [features]
-default = ["test-util"]
+default = ["test-util", "dep:log"]
 test-util = ["dep:mockall"]
 serde_json = ["dep:serde_json"]
+structured-logging = ["log?/kv"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open-feature"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.71.1"                                 # MSRV
+rust-version = "1.71.1" # MSRV
 description = "The official OpenFeature Rust SDK."
 documentation = "https://docs.rs/open-feature"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open-feature"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.71.1" # MSRV
+rust-version = "1.71.1"                                 # MSRV
 description = "The official OpenFeature Rust SDK."
 documentation = "https://docs.rs/open-feature"
 readme = "README.md"
@@ -21,13 +21,15 @@ lazy_static = "1.5"
 mockall = { version = "0.13.0", optional = true }
 serde_json = { version = "1.0.116", optional = true }
 time = "0.3.36"
-tokio = { version = "1.40", features = [ "full" ] }
+tokio = { version = "1.40", features = ["full"] }
 typed-builder = "0.20.0"
+log = "0.4.14"
 
 [dev-dependencies]
+env_logger = "0.11.5"
 spec = { path = "spec" }
 
 [features]
-default = [ "test-util" ]
-test-util = [ "dep:mockall" ]
-serde_json = [ "dep:serde_json" ]
+default = ["test-util"]
+test-util = ["dep:mockall"]
+serde_json = ["dep:serde_json"]

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -1,0 +1,150 @@
+use open_feature::{
+    provider::{FeatureProvider, ProviderMetadata, ProviderStatus, ResolutionDetails},
+    EvaluationContext, EvaluationDetails, EvaluationError, EvaluationOptions, EvaluationResult,
+    Hook, HookContext, HookHints, OpenFeature, StructValue, Value,
+};
+
+struct DummyProvider(ProviderMetadata);
+
+impl Default for DummyProvider {
+    fn default() -> Self {
+        Self(ProviderMetadata::new("Dummy Provider"))
+    }
+}
+
+#[async_trait::async_trait]
+impl FeatureProvider for DummyProvider {
+    fn metadata(&self) -> &ProviderMetadata {
+        &self.0
+    }
+
+    fn status(&self) -> ProviderStatus {
+        ProviderStatus::Ready
+    }
+
+    async fn resolve_bool_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<bool>> {
+        Ok(ResolutionDetails::new(true))
+    }
+
+    async fn resolve_int_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<i64>> {
+        unimplemented!()
+    }
+
+    async fn resolve_float_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<f64>> {
+        unimplemented!()
+    }
+
+    async fn resolve_string_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<String>> {
+        unimplemented!()
+    }
+
+    async fn resolve_struct_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> Result<ResolutionDetails<StructValue>, EvaluationError> {
+        unimplemented!()
+    }
+}
+
+struct DummyLoggingHook(String);
+
+#[async_trait::async_trait]
+impl Hook for DummyLoggingHook {
+    async fn before<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _hints: Option<&'a HookHints>,
+    ) -> Result<Option<EvaluationContext>, EvaluationError> {
+        log::info!(
+            "Evaluating({}) flag {} of type {}",
+            self.0,
+            context.flag_key,
+            context.flag_type
+        );
+
+        Ok(None)
+    }
+
+    async fn after<'a>(
+        &self,
+        context: &HookContext<'a>,
+        details: &EvaluationDetails<Value>,
+        _hints: Option<&'a HookHints>,
+    ) -> Result<(), EvaluationError> {
+        log::info!(
+            "Flag({}) {} of type {} evaluated to {:?}",
+            self.0,
+            context.flag_key,
+            context.flag_type,
+            details.value
+        );
+
+        Ok(())
+    }
+
+    async fn error<'a>(
+        &self,
+        context: &HookContext<'a>,
+        error: &EvaluationError,
+        _hints: Option<&'a HookHints>,
+    ) {
+        log::error!(
+            "Error({}) evaluating flag {} of type {}: {:?}",
+            self.0,
+            context.flag_key,
+            context.flag_type,
+            error
+        );
+    }
+
+    async fn finally<'a>(&self, context: &HookContext<'a>, _hints: Option<&'a HookHints>) {
+        log::info!(
+            "Finally({}) evaluating flag {} of type {}",
+            self.0,
+            context.flag_key,
+            context.flag_type
+        );
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let mut api = OpenFeature::singleton_mut().await;
+    api.set_provider(DummyProvider::default()).await;
+    api.add_hook(DummyLoggingHook("global".to_string())).await;
+    drop(api);
+
+    let client = OpenFeature::singleton()
+        .await
+        .create_client()
+        .with_hook(DummyLoggingHook("client".to_string())); // Add a client-level hook
+
+    let eval = EvaluationOptions::default().with_hook(DummyLoggingHook("eval".to_string()));
+    let feature = client
+        .get_bool_details("my_feature", None, Some(&eval))
+        .await
+        .unwrap();
+
+    println!("Feature value: {}", feature.value);
+}

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -114,7 +114,12 @@ impl Hook for DummyLoggingHook {
         );
     }
 
-    async fn finally<'a>(&self, context: &HookContext<'a>, _hints: Option<&'a HookHints>) {
+    async fn finally<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _: &EvaluationDetails<Value>,
+        _hints: Option<&'a HookHints>,
+    ) {
         log::info!(
             "Finally({}) evaluating flag {} of type {}",
             self.0,

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,32 @@
+use open_feature::{provider::NoOpProvider, EvaluationOptions, OpenFeature};
+
+#[tokio::main]
+async fn main() {
+    init_logger();
+
+    let mut api = OpenFeature::singleton_mut().await;
+    api.set_provider(NoOpProvider::default()).await;
+    drop(api);
+
+    let client = OpenFeature::singleton()
+        .await
+        .create_client()
+        .with_logging_hook(true); // Add a client-level hook
+
+    let eval = EvaluationOptions::default();
+    let _ = client
+        .get_bool_details("my_feature", None, Some(&eval))
+        .await;
+}
+
+#[cfg(not(feature = "structured-logging"))]
+fn init_logger() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Debug)
+        .init();
+}
+
+#[cfg(feature = "structured-logging")]
+fn init_logger() {
+    structured_logger::Builder::with_level("debug").init();
+}

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -166,6 +166,7 @@ mod tests {
         // Set the new provider and ensure the value comes from it.
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
+        provider.expect_hooks().return_const(vec![]);
         provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(200)));
@@ -213,6 +214,7 @@ mod tests {
         // Bind provider to the same name.
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
+        provider.expect_hooks().return_const(vec![]);
         provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(30)));
@@ -256,12 +258,14 @@ mod tests {
 
         let mut default_provider = MockFeatureProvider::new();
         default_provider.expect_initialize().returning(|_| {});
+        default_provider.expect_hooks().return_const(vec![]);
         default_provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(100)));
 
         let mut named_provider = MockFeatureProvider::new();
         named_provider.expect_initialize().returning(|_| {});
+        named_provider.expect_hooks().return_const(vec![]);
         named_provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(200)));
@@ -324,6 +328,7 @@ mod tests {
         // Setup expectations for different evaluation contexts.
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
+        provider.expect_hooks().return_const(vec![]);
 
         provider
             .expect_resolve_int_value()

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -58,7 +58,7 @@ impl OpenFeature {
 
     /// Add a new hook to the global list of hooks.
     pub async fn add_hook<T: Hook>(&mut self, hook: T) {
-        let mut lock = self.hooks.get_mut().await; // TODO: Remove async context to avoid deadlock and enforce initialization before usage.
+        let mut lock = self.hooks.get_mut().await;
         lock.push(HookWrapper::new(hook));
     }
 

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -168,6 +168,9 @@ mod tests {
         provider.expect_initialize().returning(|_| {});
         provider.expect_hooks().return_const(vec![]);
         provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(200)));
 
@@ -216,6 +219,9 @@ mod tests {
         provider.expect_initialize().returning(|_| {});
         provider.expect_hooks().return_const(vec![]);
         provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(30)));
         api.set_named_provider("test", provider).await;
@@ -260,12 +266,18 @@ mod tests {
         default_provider.expect_initialize().returning(|_| {});
         default_provider.expect_hooks().return_const(vec![]);
         default_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        default_provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(100)));
 
         let mut named_provider = MockFeatureProvider::new();
         named_provider.expect_initialize().returning(|_| {});
         named_provider.expect_hooks().return_const(vec![]);
+        named_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
         named_provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::new(200)));
@@ -329,6 +341,9 @@ mod tests {
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
         provider.expect_hooks().return_const(vec![]);
+        provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
 
         provider
             .expect_resolve_int_value()

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,16 +1,18 @@
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use crate::{
     provider::{FeatureProvider, ResolutionDetails},
     EvaluationContext, EvaluationDetails, EvaluationError, EvaluationErrorCode, EvaluationOptions,
-    EvaluationResult, StructValue,
+    EvaluationResult, Hook, HookContext, HookHints, HookWrapper, StructValue, Value,
 };
 
 use super::{
-    global_evaluation_context::GlobalEvaluationContext, provider_registry::ProviderRegistry,
+    global_evaluation_context::GlobalEvaluationContext, global_hooks::GlobalHooks,
+    provider_registry::ProviderRegistry,
 };
 
 /// The metadata of OpenFeature client.
+#[derive(Clone, Default, PartialEq, Debug)]
 pub struct ClientMetadata {
     /// The name of client.
     pub name: String,
@@ -23,6 +25,9 @@ pub struct Client {
     provider_registry: ProviderRegistry,
     evaluation_context: EvaluationContext,
     global_evaluation_context: GlobalEvaluationContext,
+    global_hooks: GlobalHooks,
+
+    hooks: Vec<HookWrapper>,
 }
 
 impl Client {
@@ -30,13 +35,16 @@ impl Client {
     pub fn new(
         name: impl Into<String>,
         global_evaluation_context: GlobalEvaluationContext,
+        global_hooks: GlobalHooks,
         provider_registry: ProviderRegistry,
     ) -> Self {
         Self {
             metadata: ClientMetadata { name: name.into() },
             global_evaluation_context,
+            global_hooks,
             provider_registry,
             evaluation_context: EvaluationContext::default(),
+            hooks: Vec::new(),
         }
     }
 
@@ -52,104 +60,75 @@ impl Client {
 
     /// Evaluate given `flag_key` with corresponding `evaluation_context` and `evaluation_options`
     /// as a bool value.
-    #[allow(unused_variables)]
     pub async fn get_bool_value(
         &self,
         flag_key: &str,
         evaluation_context: Option<&EvaluationContext>,
         evaluation_options: Option<&EvaluationOptions>,
     ) -> EvaluationResult<bool> {
-        let context = self.merge_evaluation_context(evaluation_context).await;
-
-        Ok(self
-            .get_provider()
+        self.get_bool_details(flag_key, evaluation_context, evaluation_options)
             .await
-            .resolve_bool_value(flag_key, &context)
-            .await?
-            .value)
+            .map(|details| details.value)
     }
 
     /// Evaluate given `flag_key` with corresponding `evaluation_context` and `evaluation_options`
     /// as an int (i64) value.
-    #[allow(unused_variables)]
     pub async fn get_int_value(
         &self,
         flag_key: &str,
         evaluation_context: Option<&EvaluationContext>,
         evaluation_options: Option<&EvaluationOptions>,
     ) -> EvaluationResult<i64> {
-        let context = self.merge_evaluation_context(evaluation_context).await;
-
-        Ok(self
-            .get_provider()
+        self.get_int_details(flag_key, evaluation_context, evaluation_options)
             .await
-            .resolve_int_value(flag_key, &context)
-            .await?
-            .value)
+            .map(|details| details.value)
     }
 
     /// Evaluate given `flag_key` with corresponding `evaluation_context` and `evaluation_options`
     /// as a float (f64) value.
     /// If the resolution fails, the `default_value` is returned.
-    #[allow(unused_variables)]
     pub async fn get_float_value(
         &self,
         flag_key: &str,
         evaluation_context: Option<&EvaluationContext>,
         evaluation_options: Option<&EvaluationOptions>,
     ) -> EvaluationResult<f64> {
-        let context = self.merge_evaluation_context(evaluation_context).await;
-
-        Ok(self
-            .get_provider()
+        self.get_float_details(flag_key, evaluation_context, evaluation_options)
             .await
-            .resolve_float_value(flag_key, &context)
-            .await?
-            .value)
+            .map(|details| details.value)
     }
 
     /// Evaluate given `flag_key` with corresponding `evaluation_context` and `evaluation_options`
     /// as a string value.
     /// If the resolution fails, the `default_value` is returned.
-    #[allow(unused_variables)]
     pub async fn get_string_value(
         &self,
         flag_key: &str,
         evaluation_context: Option<&EvaluationContext>,
         evaluation_options: Option<&EvaluationOptions>,
     ) -> EvaluationResult<String> {
-        let context = self.merge_evaluation_context(evaluation_context).await;
-
-        Ok(self
-            .get_provider()
+        self.get_string_details(flag_key, evaluation_context, evaluation_options)
             .await
-            .resolve_string_value(flag_key, &context)
-            .await?
-            .value)
+            .map(|details| details.value)
     }
 
     /// Evaluate given `flag_key` with corresponding `evaluation_context` and `evaluation_options`
     /// as a struct.
     /// If the resolution fails, the `default_value` is returned.
     /// The required type should implement [`From<StructValue>`] trait.
-    #[allow(unused_variables)]
     pub async fn get_struct_value<T: TryFrom<StructValue>>(
         &self,
         flag_key: &str,
         evaluation_context: Option<&EvaluationContext>,
         evaluation_options: Option<&EvaluationOptions>,
     ) -> EvaluationResult<T> {
-        let context = self.merge_evaluation_context(evaluation_context).await;
-
         let result = self
-            .get_provider()
-            .await
-            .resolve_struct_value(flag_key, &context)
+            .get_struct_details(flag_key, evaluation_context, evaluation_options)
             .await?;
 
         match T::try_from(result.value) {
             Ok(t) => Ok(t),
-            Err(error) => Err(EvaluationError {
+            Err(_) => Err(EvaluationError {
                 code: EvaluationErrorCode::TypeMismatch,
                 message: Some("Unable to cast value to required type".to_string()),
             }),
@@ -158,7 +137,6 @@ impl Client {
 
     /// Return the [`EvaluationDetails`] with given `flag_key`, `evaluation_context` and
     /// `evaluation_options`.
-    #[allow(unused_variables)]
     pub async fn get_bool_details(
         &self,
         flag_key: &str,
@@ -167,17 +145,17 @@ impl Client {
     ) -> EvaluationResult<EvaluationDetails<bool>> {
         let context = self.merge_evaluation_context(evaluation_context).await;
 
-        Ok(self
-            .get_provider()
-            .await
-            .resolve_bool_value(flag_key, &context)
-            .await?
-            .into_evaluation_details(flag_key))
+        self.evaluate(
+            flag_key,
+            &context,
+            evaluation_options,
+            call_resolve_bool_value,
+        )
+        .await
     }
 
     /// Return the [`EvaluationDetails`] with given `flag_key`, `evaluation_context` and
     /// `evaluation_options`.
-    #[allow(unused_variables)]
     pub async fn get_int_details(
         &self,
         flag_key: &str,
@@ -186,17 +164,17 @@ impl Client {
     ) -> EvaluationResult<EvaluationDetails<i64>> {
         let context = self.merge_evaluation_context(evaluation_context).await;
 
-        Ok(self
-            .get_provider()
-            .await
-            .resolve_int_value(flag_key, &context)
-            .await?
-            .into_evaluation_details(flag_key))
+        self.evaluate(
+            flag_key,
+            &context,
+            evaluation_options,
+            call_resolve_int_value,
+        )
+        .await
     }
 
     /// Return the [`EvaluationDetails`] with given `flag_key`, `evaluation_context` and
     /// `evaluation_options`.
-    #[allow(unused_variables)]
     pub async fn get_float_details(
         &self,
         flag_key: &str,
@@ -205,17 +183,17 @@ impl Client {
     ) -> EvaluationResult<EvaluationDetails<f64>> {
         let context = self.merge_evaluation_context(evaluation_context).await;
 
-        Ok(self
-            .get_provider()
-            .await
-            .resolve_float_value(flag_key, &context)
-            .await?
-            .into_evaluation_details(flag_key))
+        self.evaluate(
+            flag_key,
+            &context,
+            evaluation_options,
+            call_resolve_float_value,
+        )
+        .await
     }
 
     /// Return the [`EvaluationDetails`] with given `flag_key`, `evaluation_context` and
     /// `evaluation_options`.
-    #[allow(unused_variables)]
     pub async fn get_string_details(
         &self,
         flag_key: &str,
@@ -224,17 +202,17 @@ impl Client {
     ) -> EvaluationResult<EvaluationDetails<String>> {
         let context = self.merge_evaluation_context(evaluation_context).await;
 
-        Ok(self
-            .get_provider()
-            .await
-            .resolve_string_value(flag_key, &context)
-            .await?
-            .into_evaluation_details(flag_key))
+        self.evaluate(
+            flag_key,
+            &context,
+            evaluation_options,
+            call_resolve_string_value,
+        )
+        .await
     }
 
     /// Return the [`EvaluationDetails`] with given `flag_key`, `evaluation_context` and
     /// `evaluation_options`.
-    #[allow(unused_variables)]
     pub async fn get_struct_details<T: TryFrom<StructValue>>(
         &self,
         flag_key: &str,
@@ -244,9 +222,12 @@ impl Client {
         let context = self.merge_evaluation_context(evaluation_context).await;
 
         let result = self
-            .get_provider()
-            .await
-            .resolve_struct_value(flag_key, &context)
+            .evaluate(
+                flag_key,
+                &context,
+                evaluation_options,
+                call_resolve_struct_value,
+            )
             .await?;
 
         match T::try_from(result.value) {
@@ -255,9 +236,9 @@ impl Client {
                 value,
                 reason: result.reason,
                 variant: result.variant,
-                flag_metadata: result.flag_metadata.unwrap_or_default(),
+                flag_metadata: result.flag_metadata,
             }),
-            Err(error) => Err(EvaluationError {
+            Err(_) => Err(EvaluationError {
                 code: EvaluationErrorCode::TypeMismatch,
                 message: Some("Unable to cast value to required type".to_string()),
             }),
@@ -289,6 +270,187 @@ impl Client {
     }
 }
 
+impl Client {
+    /// Add a hook to the client.
+    #[must_use]
+    pub fn with_hook<T: Hook>(mut self, hook: T) -> Self {
+        self.hooks.push(HookWrapper::new(hook));
+        self
+    }
+
+    /// Add logging hook to the client.
+    #[must_use]
+    pub fn with_logging_hook(self) -> Self {
+        self.with_hook(crate::LoggingHook)
+    }
+
+    async fn evaluate<T>(
+        &self,
+        flag_key: &str,
+        context: &EvaluationContext,
+        evaluation_options: Option<&EvaluationOptions>, // INFO: Invocation
+        resolve: impl for<'a> FnOnce(
+            &'a dyn FeatureProvider,
+            &'a str,
+            &'a EvaluationContext,
+        ) -> Pin<
+            Box<dyn Future<Output = EvaluationResult<ResolutionDetails<T>>> + Send + 'a>,
+        >,
+    ) -> EvaluationResult<EvaluationDetails<T>>
+    where
+        T: Into<Value> + Clone + Default,
+    {
+        let provider = self.get_provider().await;
+        let hints = evaluation_options.map(|options| &options.hints);
+
+        let default: Value = T::default().into();
+
+        let mut hook_context = HookContext {
+            flag_key,
+            flag_type: default.get_type(),
+            client_metadata: self.metadata.clone(),
+            evaluation_context: context,
+
+            default_value: Some(default),
+        };
+
+        let global_hooks = self.global_hooks.get().await;
+        let client_hooks = &self.hooks[..];
+        let invocation_hooks: &[HookWrapper] = evaluation_options
+            .map(|options| options.hooks.as_ref())
+            .unwrap_or_default();
+        let provider_hooks = provider.hooks();
+
+        // INFO: API(global), Client, Invocation, Provider
+        // https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md#requirement-442
+        let before_hooks = global_hooks
+            .iter()
+            .chain(client_hooks.iter())
+            .chain(invocation_hooks.iter())
+            .chain(provider_hooks.iter());
+
+        // INFO: Hooks called after the resolution are in reverse order
+        // Provider, Invocation, Client, API(global)
+        let after_hooks = before_hooks.clone().rev();
+
+        let (context, result) = self
+            .before_hooks(before_hooks.into_iter(), &hook_context, hints)
+            .await;
+        hook_context.evaluation_context = &context;
+
+        if let Err(error) = result {
+            self.error_hooks(after_hooks.clone(), &hook_context, &error, hints)
+                .await;
+            self.finally_hooks(after_hooks.into_iter(), &hook_context, hints)
+                .await;
+
+            return Err(error);
+        }
+
+        // INFO: Run the resolution
+        let result = resolve(&*provider, flag_key, &context)
+            .await
+            .map(|details| details.into_evaluation_details(flag_key));
+
+        // INFO: Run the after hooks
+        match result {
+            Ok(ref details) => {
+                let details = details.clone().into_value();
+                if let Err(error) = self
+                    .after_hooks(after_hooks.clone(), &hook_context, &details, hints)
+                    .await
+                {
+                    self.error_hooks(after_hooks.clone(), &hook_context, &error, hints)
+                        .await;
+                }
+            }
+            Err(ref error) => {
+                self.error_hooks(after_hooks.clone(), &hook_context, error, hints)
+                    .await;
+            }
+        }
+
+        self.finally_hooks(after_hooks.into_iter(), &hook_context, hints)
+            .await;
+
+        result
+    }
+
+    async fn before_hooks<'a, I>(
+        &self,
+        hooks: I,
+        hook_context: &HookContext<'_>,
+        hints: Option<&HookHints>,
+    ) -> (EvaluationContext, EvaluationResult<()>)
+    where
+        I: Iterator<Item = &'a HookWrapper>,
+    {
+        let mut context = EvaluationContext::default();
+        for hook in hooks {
+            let invoke_hook_context = HookContext {
+                evaluation_context: &context,
+                ..hook_context.clone()
+            };
+            match hook.before(&invoke_hook_context, hints).await {
+                Ok(Some(output)) => context = output,
+                Ok(None) => { /* INFO: just continue execution */ }
+                Err(error) => {
+                    drop(invoke_hook_context);
+                    context.merge_missing(hook_context.evaluation_context);
+                    return (context, Err(error));
+                }
+            }
+        }
+
+        context.merge_missing(hook_context.evaluation_context);
+        (context, Ok(()))
+    }
+
+    async fn after_hooks<'a, I>(
+        &self,
+        hooks: I,
+        hook_context: &HookContext<'_>,
+        details: &EvaluationDetails<Value>,
+        hints: Option<&HookHints>,
+    ) -> EvaluationResult<()>
+    where
+        I: Iterator<Item = &'a HookWrapper>,
+    {
+        for hook in hooks {
+            hook.after(hook_context, details, hints).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn error_hooks<'a, I>(
+        &self,
+        hooks: I,
+        hook_context: &HookContext<'_>,
+        error: &EvaluationError,
+        hints: Option<&HookHints>,
+    ) where
+        I: Iterator<Item = &'a HookWrapper>,
+    {
+        for hook in hooks {
+            hook.error(hook_context, error, hints).await;
+        }
+    }
+
+    async fn finally_hooks<'a, I>(
+        &self,
+        hooks: I,
+        hook_context: &HookContext<'_>,
+        hints: Option<&HookHints>,
+    ) where
+        I: Iterator<Item = &'a HookWrapper>,
+    {
+        for hook in hooks {
+            hook.finally(hook_context, hints).await;
+        }
+    }
+}
+
 impl<T> ResolutionDetails<T> {
     fn into_evaluation_details(self, flag_key: impl Into<String>) -> EvaluationDetails<T> {
         EvaluationDetails {
@@ -301,6 +463,46 @@ impl<T> ResolutionDetails<T> {
     }
 }
 
+fn call_resolve_bool_value<'a>(
+    provider: &'a dyn FeatureProvider,
+    flag_key: &'a str,
+    context: &'a EvaluationContext,
+) -> Pin<Box<dyn Future<Output = EvaluationResult<ResolutionDetails<bool>>> + Send + 'a>> {
+    Box::pin(async move { provider.resolve_bool_value(flag_key, context).await })
+}
+
+fn call_resolve_int_value<'a>(
+    provider: &'a dyn FeatureProvider,
+    flag_key: &'a str,
+    context: &'a EvaluationContext,
+) -> Pin<Box<dyn Future<Output = EvaluationResult<ResolutionDetails<i64>>> + Send + 'a>> {
+    Box::pin(async move { provider.resolve_int_value(flag_key, context).await })
+}
+
+fn call_resolve_float_value<'a>(
+    provider: &'a dyn FeatureProvider,
+    flag_key: &'a str,
+    context: &'a EvaluationContext,
+) -> Pin<Box<dyn Future<Output = EvaluationResult<ResolutionDetails<f64>>> + Send + 'a>> {
+    Box::pin(async move { provider.resolve_float_value(flag_key, context).await })
+}
+
+fn call_resolve_string_value<'a>(
+    provider: &'a dyn FeatureProvider,
+    flag_key: &'a str,
+    context: &'a EvaluationContext,
+) -> Pin<Box<dyn Future<Output = EvaluationResult<ResolutionDetails<String>>> + Send + 'a>> {
+    Box::pin(async move { provider.resolve_string_value(flag_key, context).await })
+}
+
+fn call_resolve_struct_value<'a>(
+    provider: &'a dyn FeatureProvider,
+    flag_key: &'a str,
+    context: &'a EvaluationContext,
+) -> Pin<Box<dyn Future<Output = EvaluationResult<ResolutionDetails<StructValue>>> + Send + 'a>> {
+    Box::pin(async move { provider.resolve_struct_value(flag_key, context).await })
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -308,7 +510,8 @@ mod tests {
 
     use crate::{
         api::{
-            global_evaluation_context::GlobalEvaluationContext, provider_registry::ProviderRegistry,
+            global_evaluation_context::GlobalEvaluationContext, global_hooks::GlobalHooks,
+            provider_registry::ProviderRegistry,
         },
         provider::{FeatureProvider, MockFeatureProvider, ResolutionDetails},
         Client, EvaluationReason, FlagMetadata, StructValue, Value,
@@ -544,10 +747,35 @@ mod tests {
     #[test]
     fn static_context_not_applicable() {}
 
+    #[tokio::test]
+    async fn with_hook() {
+        let mut provider = MockFeatureProvider::new();
+        provider.expect_initialize().returning(|_| {});
+
+        let client = create_client(provider).await;
+
+        let client = client.with_hook(crate::LoggingHook);
+
+        assert_eq!(client.hooks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn with_logging_hook() {
+        let mut provider = MockFeatureProvider::new();
+        provider.expect_initialize().returning(|_| {});
+
+        let client = create_client(provider).await;
+
+        let client = client.with_logging_hook();
+
+        assert_eq!(client.hooks.len(), 1);
+    }
+
     fn create_default_client() -> Client {
         Client::new(
             "no_op",
             GlobalEvaluationContext::default(),
+            GlobalHooks::default(),
             ProviderRegistry::default(),
         )
     }
@@ -559,6 +787,7 @@ mod tests {
         Client::new(
             "custom",
             GlobalEvaluationContext::default(),
+            GlobalHooks::default(),
             provider_registry,
         )
     }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -385,7 +385,7 @@ impl Client {
     where
         I: Iterator<Item = &'a HookWrapper>,
     {
-        let mut context = EvaluationContext::default();
+        let mut context = hook_context.evaluation_context.clone();
         for hook in hooks {
             let invoke_hook_context = HookContext {
                 evaluation_context: &context,
@@ -567,6 +567,7 @@ mod tests {
         // Test bool.
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
+        provider.expect_hooks().return_const(vec![]);
 
         provider
             .expect_resolve_bool_value()
@@ -667,6 +668,7 @@ mod tests {
     async fn get_details() {
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
+        provider.expect_hooks().return_const(vec![]);
         provider
             .expect_resolve_int_value()
             .return_const(Ok(ResolutionDetails::builder()
@@ -719,6 +721,7 @@ mod tests {
     async fn get_details_flag_metadata() {
         let mut provider = MockFeatureProvider::new();
         provider.expect_initialize().returning(|_| {});
+        provider.expect_hooks().return_const(vec![]);
         provider
             .expect_resolve_bool_value()
             .return_const(Ok(ResolutionDetails::builder()

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -27,7 +27,7 @@ pub struct Client {
     global_evaluation_context: GlobalEvaluationContext,
     global_hooks: GlobalHooks,
 
-    hooks: Vec<HookWrapper>,
+    client_hooks: Vec<HookWrapper>,
 }
 
 impl Client {
@@ -44,7 +44,7 @@ impl Client {
             global_hooks,
             provider_registry,
             evaluation_context: EvaluationContext::default(),
-            hooks: Vec::new(),
+            client_hooks: Vec::new(),
         }
     }
 
@@ -274,7 +274,7 @@ impl Client {
     /// Add a hook to the client.
     #[must_use]
     pub fn with_hook<T: Hook>(mut self, hook: T) -> Self {
-        self.hooks.push(HookWrapper::new(hook));
+        self.client_hooks.push(HookWrapper::new(hook));
         self
     }
 
@@ -315,7 +315,7 @@ impl Client {
         };
 
         let global_hooks = self.global_hooks.get().await;
-        let client_hooks = &self.hooks[..];
+        let client_hooks = &self.client_hooks[..];
         let invocation_hooks: &[HookWrapper] = evaluation_options
             .map(|options| options.hooks.as_ref())
             .unwrap_or_default();
@@ -779,7 +779,7 @@ mod tests {
 
         let client = client.with_hook(crate::LoggingHook);
 
-        assert_eq!(client.hooks.len(), 1);
+        assert_eq!(client.client_hooks.len(), 1);
     }
 
     #[tokio::test]
@@ -791,7 +791,7 @@ mod tests {
 
         let client = client.with_logging_hook();
 
-        assert_eq!(client.hooks.len(), 1);
+        assert_eq!(client.client_hooks.len(), 1);
     }
 
     fn create_default_client() -> Client {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -338,7 +338,7 @@ impl Client {
             .await;
         hook_context.evaluation_context = &context;
 
-        // INFO: Result of the resolution or error reson with default value
+        // INFO: Result of the resolution or error reason with default value
         // This bind is defined here to minimize cloning of the `Value`
         let evaluation_details;
 

--- a/src/api/global_hooks.rs
+++ b/src/api/global_hooks.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::HookWrapper;
+
+#[derive(Clone, Default)]
+pub struct GlobalHooks(Arc<RwLock<Vec<HookWrapper>>>);
+
+impl GlobalHooks {
+    pub async fn get(&self) -> RwLockReadGuard<Vec<HookWrapper>> {
+        self.0.read().await
+    }
+
+    pub async fn get_mut(&self) -> RwLockWriteGuard<Vec<HookWrapper>> {
+        self.0.write().await
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,3 +7,4 @@ pub use client::{Client, ClientMetadata};
 mod provider_registry;
 
 mod global_evaluation_context;
+mod global_hooks;

--- a/src/evaluation/context_field_value.rs
+++ b/src/evaluation/context_field_value.rs
@@ -11,7 +11,7 @@ pub enum EvaluationContextFieldValue {
     Float(f64),
     String(String),
     DateTime(OffsetDateTime),
-    Struct(Arc<dyn Any + Send + Sync>),
+    Struct(Arc<dyn Any + Send + Sync>), // TODO: better to make structure in similar way as serde_json::Value
 }
 
 impl EvaluationContextFieldValue {

--- a/src/evaluation/details.rs
+++ b/src/evaluation/details.rs
@@ -33,6 +33,19 @@ pub struct EvaluationDetails<T> {
     pub flag_metadata: FlagMetadata,
 }
 
+impl EvaluationDetails<Value> {
+    /// Creates a new `EvaluationDetails` instance with an error reason.
+    pub fn error_reason(flag_key: impl Into<String>, value: impl Into<Value>) -> Self {
+        Self {
+            value: value.into(),
+            flag_key: flag_key.into(),
+            reason: Some(EvaluationReason::Error),
+            variant: None,
+            flag_metadata: FlagMetadata::default(),
+        }
+    }
+}
+
 impl<T> EvaluationDetails<T>
 where
     T: Into<Value>,

--- a/src/evaluation/details.rs
+++ b/src/evaluation/details.rs
@@ -3,6 +3,8 @@ use std::fmt::{Display, Formatter};
 
 use crate::EvaluationError;
 
+use super::Value;
+
 /// The result of evaluation.
 pub type EvaluationResult<T> = Result<T, EvaluationError>;
 
@@ -29,6 +31,22 @@ pub struct EvaluationDetails<T> {
     /// The optional flag metadata returned by the configured provider.
     /// If the provider returns nothing, it is set to the default value.
     pub flag_metadata: FlagMetadata,
+}
+
+impl<T> EvaluationDetails<T>
+where
+    T: Into<Value>,
+{
+    /// Convert the evaluation result of type `T` to `Value`.
+    pub fn into_value(self) -> EvaluationDetails<Value> {
+        EvaluationDetails {
+            flag_key: self.flag_key,
+            value: self.value.into(),
+            reason: self.reason,
+            variant: self.variant,
+            flag_metadata: self.flag_metadata,
+        }
+    }
 }
 
 // ============================================================

--- a/src/evaluation/error.rs
+++ b/src/evaluation/error.rs
@@ -2,6 +2,7 @@
 //  EvaluationError
 // ============================================================
 
+use std::error::Error as StdError;
 use std::fmt::{Display, Formatter};
 use typed_builder::TypedBuilder;
 
@@ -59,3 +60,5 @@ impl Display for EvaluationErrorCode {
         write!(f, "{code}")
     }
 }
+
+impl StdError for EvaluationErrorCode {}

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -13,7 +13,7 @@ mod context_field_value;
 pub use context_field_value::EvaluationContextFieldValue;
 
 mod value;
-pub use value::{StructValue, Value};
+pub use value::{StructValue, Type, Value};
 
 mod options;
 pub use options::EvaluationOptions;

--- a/src/evaluation/options.rs
+++ b/src/evaluation/options.rs
@@ -1,2 +1,25 @@
+use crate::Hook;
+
 /// Contain hooks.
-pub struct EvaluationOptions {}
+#[derive(Default, Clone)]
+pub struct EvaluationOptions {
+    /// The hooks to be used during evaluation.
+    pub hooks: Vec<crate::hooks::HookWrapper>,
+
+    /// Hints to be passed to the hooks.
+    pub hints: crate::hooks::HookHints,
+}
+
+impl EvaluationOptions {
+    /// Create a new instance of `EvaluationOptions`.
+    pub fn new(hooks: Vec<crate::hooks::HookWrapper>, hints: crate::hooks::HookHints) -> Self {
+        Self { hooks, hints }
+    }
+
+    /// Add a hook to the evaluation options.
+    #[must_use]
+    pub fn with_hook<T: Hook + 'static>(mut self, hook: T) -> Self {
+        self.hooks.push(crate::hooks::HookWrapper::new(hook));
+        self
+    }
+}

--- a/src/evaluation/value.rs
+++ b/src/evaluation/value.rs
@@ -12,6 +12,19 @@ pub enum Value {
     Struct(StructValue),
 }
 
+/// Supported types of values.
+/// [spec](https://openfeature.dev/specification/types).
+#[derive(Clone, PartialEq, Debug)]
+#[allow(missing_docs)]
+pub enum Type {
+    Bool,
+    Int,
+    Float,
+    String,
+    Array,
+    Struct,
+}
+
 /// Represent a structure value as defined in the
 /// [spec](https://openfeature.dev/specification/types#structure).
 #[derive(Clone, Default, PartialEq, Debug)]
@@ -96,6 +109,18 @@ impl Value {
         match self {
             Self::Struct(value) => Some(value),
             _ => None,
+        }
+    }
+
+    /// Return the type of the value.
+    pub fn get_type(&self) -> Type {
+        match self {
+            Self::Bool(_) => Type::Bool,
+            Self::Int(_) => Type::Int,
+            Self::Float(_) => Type::Float,
+            Self::String(_) => Type::String,
+            Self::Array(_) => Type::Array,
+            Self::Struct(_) => Type::Struct,
         }
     }
 }
@@ -198,6 +223,19 @@ impl StructValue {
     /// Append given `key` and `value` to `self` in place.
     pub fn add_field(&mut self, key: impl Into<String>, value: impl Into<Value>) {
         self.fields.insert(key.into(), value.into());
+    }
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bool => write!(f, "bool"),
+            Self::Int => write!(f, "int"),
+            Self::Float => write!(f, "float"),
+            Self::String => write!(f, "string"),
+            Self::Array => write!(f, "array"),
+            Self::Struct => write!(f, "struct"),
+        }
     }
 }
 

--- a/src/hooks/logging.rs
+++ b/src/hooks/logging.rs
@@ -34,7 +34,12 @@ impl Hook for LoggingHook {
     ) {
         log::error!("Error hook for flag {}: {:?}", context.flag_key, error);
     }
-    async fn finally<'a>(&self, context: &HookContext<'a>, _: Option<&'a HookHints>) {
+    async fn finally<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _: &EvaluationDetails<Value>,
+        _: Option<&'a HookHints>,
+    ) {
         log::trace!("Finally hook for flag {}", context.flag_key);
     }
 }

--- a/src/hooks/logging.rs
+++ b/src/hooks/logging.rs
@@ -1,0 +1,40 @@
+use crate::{EvaluationContext, EvaluationDetails, EvaluationError, Value};
+
+use super::{Hook, HookContext, HookHints};
+
+/// A hook that logs the evaluation lifecycle of a flag.
+pub struct LoggingHook;
+
+#[async_trait::async_trait]
+impl Hook for LoggingHook {
+    async fn before<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _: Option<&'a HookHints>,
+    ) -> Result<Option<EvaluationContext>, EvaluationError> {
+        log::debug!("Before hook for flag {}", context.flag_key);
+
+        Ok(None)
+    }
+    async fn after<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _: &EvaluationDetails<Value>,
+        _: Option<&'a HookHints>,
+    ) -> Result<(), EvaluationError> {
+        log::debug!("After hook for flag {}", context.flag_key);
+
+        Ok(())
+    }
+    async fn error<'a>(
+        &self,
+        context: &HookContext<'a>,
+        error: &EvaluationError,
+        _: Option<&'a HookHints>,
+    ) {
+        log::error!("Error hook for flag {}: {:?}", context.flag_key, error);
+    }
+    async fn finally<'a>(&self, context: &HookContext<'a>, _: Option<&'a HookHints>) {
+        log::trace!("Finally hook for flag {}", context.flag_key);
+    }
+}

--- a/src/hooks/logging.rs
+++ b/src/hooks/logging.rs
@@ -2,8 +2,14 @@ use crate::{EvaluationContext, EvaluationDetails, EvaluationError, Value};
 
 use super::{Hook, HookContext, HookHints};
 
+use log::Level;
+
 /// A hook that logs the evaluation lifecycle of a flag.
-pub struct LoggingHook;
+/// See the [spec](https://github.com/open-feature/spec/blob/main/specification/appendix-a-included-utilities.md#logging-hook)
+#[derive(Default)]
+pub struct LoggingHook {
+    pub(crate) include_evaluation_context: bool,
+}
 
 #[async_trait::async_trait]
 impl Hook for LoggingHook {
@@ -12,17 +18,17 @@ impl Hook for LoggingHook {
         context: &HookContext<'a>,
         _: Option<&'a HookHints>,
     ) -> Result<Option<EvaluationContext>, EvaluationError> {
-        log::debug!("Before hook for flag {}", context.flag_key);
+        self.log_before(context, Level::Debug);
 
         Ok(None)
     }
     async fn after<'a>(
         &self,
         context: &HookContext<'a>,
-        _: &EvaluationDetails<Value>,
+        value: &EvaluationDetails<Value>,
         _: Option<&'a HookHints>,
     ) -> Result<(), EvaluationError> {
-        log::debug!("After hook for flag {}", context.flag_key);
+        self.log_after(context, value, Level::Debug);
 
         Ok(())
     }
@@ -32,14 +38,171 @@ impl Hook for LoggingHook {
         error: &EvaluationError,
         _: Option<&'a HookHints>,
     ) {
-        log::error!("Error hook for flag {}: {:?}", context.flag_key, error);
+        self.log_error(context, error);
     }
     async fn finally<'a>(
         &self,
-        context: &HookContext<'a>,
+        _: &HookContext<'a>,
         _: &EvaluationDetails<Value>,
         _: Option<&'a HookHints>,
     ) {
-        log::trace!("Finally hook for flag {}", context.flag_key);
+    }
+}
+
+#[cfg(not(feature = "structured-logging"))]
+impl LoggingHook {
+    fn log_args(
+        &self,
+        msg: &str,
+        context: &HookContext,
+        level: Level,
+        additional_args: std::fmt::Arguments,
+    ) {
+        log::log!(
+            level,
+            "{}: domain={}, provider_name={}, flag_key={}, default_value={:?}{additional_args}{}",
+            msg,
+            context.client_metadata.name,
+            context.provider_metadata.name,
+            context.flag_key,
+            context.default_value,
+            if self.include_evaluation_context {
+                format!(", evaluation_context={:?}", context.evaluation_context)
+            } else {
+                String::new()
+            },
+        );
+    }
+
+    fn log_before(&self, context: &HookContext, level: Level) {
+        self.log_args("Before stage", context, level, format_args!(""));
+    }
+
+    fn log_after(&self, context: &HookContext, value: &EvaluationDetails<Value>, level: Level) {
+        self.log_args(
+            "After stage",
+            context,
+            level,
+            format_args!(
+                ", reason={:?}, variant={:?}, value={:?}",
+                value.reason, value.variant, value.value
+            ),
+        );
+    }
+
+    fn log_error(&self, context: &HookContext, error: &EvaluationError) {
+        self.log_args(
+            "Error stage",
+            context,
+            Level::Error,
+            format_args!(", error_message={:?}", error.message),
+        );
+    }
+}
+
+#[cfg(feature = "structured-logging")]
+mod structured {
+    use super::*;
+    use log::{kv::Value as LogValue, Level, Record};
+
+    const DOMAIN_KEY: &str = "domain";
+    const PROVIDER_NAME_KEY: &str = "provider_name";
+    const FLAG_KEY_KEY: &str = "flag_key";
+    const DEFAULT_VALUE_KEY: &str = "default_value";
+    const EVALUATION_CONTEXT_KEY: &str = "evaluation_context";
+    const ERROR_MESSAGE_KEY: &str = "error_message";
+    const REASON_KEY: &str = "reason";
+    const VARIANT_KEY: &str = "variant";
+    const VALUE_KEY: &str = "value";
+
+    impl LoggingHook {
+        fn log_args(
+            &self,
+            msg: &str,
+            context: &HookContext,
+            level: Level,
+            additional_kvs: Vec<(&str, LogValue)>,
+        ) {
+            let mut kvs = vec![
+                (
+                    DOMAIN_KEY,
+                    LogValue::from_display(&context.client_metadata.name),
+                ),
+                (
+                    PROVIDER_NAME_KEY,
+                    LogValue::from_display(&context.provider_metadata.name),
+                ),
+                (FLAG_KEY_KEY, LogValue::from_display(&context.flag_key)),
+                (
+                    DEFAULT_VALUE_KEY,
+                    LogValue::from_debug(&context.default_value),
+                ),
+            ];
+
+            kvs.extend(additional_kvs);
+
+            if self.include_evaluation_context {
+                kvs.push((
+                    EVALUATION_CONTEXT_KEY,
+                    LogValue::from_debug(&context.evaluation_context),
+                ));
+            }
+
+            let kvs = kvs.as_slice();
+
+            // Single statement to avoid borrowing issues
+            // See issue https://github.com/rust-lang/rust/issues/92698
+            log::logger().log(
+                &Record::builder()
+                    .args(format_args!("{}", msg))
+                    .level(level)
+                    .target("open_feature")
+                    .module_path_static(Some(module_path!()))
+                    .file_static(Some(file!()))
+                    .line(Some(line!()))
+                    .key_values(&kvs)
+                    .build(),
+            );
+        }
+
+        pub(super) fn log_before(&self, context: &HookContext, level: Level) {
+            self.log_args("Before stage", context, level, vec![]);
+        }
+
+        pub(super) fn log_after(
+            &self,
+            context: &HookContext,
+            value: &EvaluationDetails<Value>,
+            level: Level,
+        ) {
+            self.log_args(
+                "After stage",
+                context,
+                level,
+                evaluation_details_to_kvs(value),
+            );
+        }
+
+        pub(super) fn log_error(&self, context: &HookContext, error: &EvaluationError) {
+            self.log_args("Error stage", context, Level::Error, error_to_kvs(error));
+        }
+    }
+
+    fn evaluation_details_to_kvs<'a>(
+        details: &'a EvaluationDetails<Value>,
+    ) -> Vec<(&'static str, LogValue<'a>)> {
+        let kvs = vec![
+            (REASON_KEY, LogValue::from_debug(&details.reason)),
+            (VARIANT_KEY, LogValue::from_debug(&details.variant)),
+            (VALUE_KEY, LogValue::from_debug(&details.value)),
+        ];
+
+        kvs
+    }
+
+    fn error_to_kvs<'a>(error: &'a EvaluationError) -> Vec<(&'static str, LogValue<'a>)> {
+        let kvs = vec![(ERROR_MESSAGE_KEY, LogValue::from_debug(&error.message))];
+
+        kvs
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -207,7 +207,7 @@ mod tests {
         let mut mock_hook_1 = MockHook::new();
         let mut mock_hook_2 = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         let mut client = api.create_named_client("test");
         let mut mock_provider = MockFeatureProvider::default();
 
@@ -215,6 +215,15 @@ mod tests {
         mock_provider.expect_initialize().return_const(());
         mock_provider
             .expect_resolve_bool_value()
+            .withf(|_, ctx| {
+                assert_eq!(
+                    ctx,
+                    &EvaluationContext::default()
+                        .with_targeting_key("mock_hook_1")
+                        .with_custom_field("is", "a test")
+                );
+                true
+            })
             .return_const(Ok(ResolutionDetails::new(true)));
 
         api.set_provider(mock_provider).await;
@@ -247,7 +256,7 @@ mod tests {
                 ))
             });
 
-        let expected_eval_ctx_2 = eval_ctx.clone().with_targeting_key("mock_hook_1");
+        let expected_eval_ctx_2 = EvaluationContext::default().with_targeting_key("mock_hook_1");
         let client_metadata = client.metadata().clone();
         mock_hook_2
             .expect_before()
@@ -287,7 +296,7 @@ mod tests {
     async fn before_hook_context_merging() {
         let mut mock_hook = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         api.set_evaluation_context(
             EvaluationContext::default()
                 .with_custom_field("key", "api context")
@@ -359,7 +368,7 @@ mod tests {
     async fn after_hook() {
         let mut mock_hook = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         let mut client = api.create_client();
         let mut mock_provider = MockFeatureProvider::default();
 
@@ -407,7 +416,7 @@ mod tests {
         {
             let mut mock_hook = MockHook::new();
 
-            let mut api = OpenFeature::singleton_mut().await;
+            let mut api = OpenFeature::default();
             let mut client = api.create_client();
             let mut mock_provider = MockFeatureProvider::default();
 
@@ -445,7 +454,7 @@ mod tests {
         {
             let mut mock_hook = MockHook::new();
 
-            let mut api = OpenFeature::singleton_mut().await;
+            let mut api = OpenFeature::default();
             let mut client = api.create_client();
             let mut mock_provider = MockFeatureProvider::default();
 
@@ -493,7 +502,7 @@ mod tests {
     async fn finally_hook() {
         let mut mock_hook = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         let mut client = api.create_client();
         let mut mock_provider = MockFeatureProvider::default();
 
@@ -506,7 +515,6 @@ mod tests {
             .return_const(Ok(ResolutionDetails::new(true)));
 
         api.set_provider(mock_provider).await;
-        drop(api);
 
         mock_hook
             .expect_before()
@@ -551,7 +559,7 @@ mod tests {
         let mut mock_provider_hook = MockHook::new();
         let mut mock_invocation_hook = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         let mut client = api.create_client();
         let mut provider = MockFeatureProvider::default();
 
@@ -665,7 +673,7 @@ mod tests {
     async fn error_hook_invoked_on_error() {
         let mut mock_hook = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         let mut client = api.create_client();
         let mut mock_provider = MockFeatureProvider::default();
 
@@ -676,7 +684,6 @@ mod tests {
         mock_provider.expect_resolve_bool_value().never();
 
         api.set_provider(mock_provider).await;
-        drop(api);
 
         mock_hook
             .expect_before()
@@ -714,7 +721,7 @@ mod tests {
         let mut mock_provider_hook = MockHook::new();
         let mut mock_invocation_hook = MockHook::new();
 
-        let mut api = OpenFeature::singleton_mut().await;
+        let mut api = OpenFeature::default();
         let mut client = api.create_client();
         let mut provider = MockFeatureProvider::default();
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,820 @@
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+use crate::{ClientMetadata, EvaluationContext, EvaluationDetails, EvaluationError, Type, Value};
+
+mod logging;
+pub use logging::LoggingHook;
+
+// ============================================================
+//  Hook
+// ============================================================
+
+/// Hook allows application developers to add arbitrary behavior to the flag evaluation lifecycle.
+/// They operate similarly to middleware in many web frameworks.
+///
+/// https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md
+#[cfg_attr(
+    feature = "test-util",
+    mockall::automock,
+    allow(clippy::ref_option_ref)
+)] // Specified lifetimes manually to make it work with mockall
+#[async_trait::async_trait]
+pub trait Hook: Send + Sync + 'static {
+    /// This method is called before the flag evaluation.
+    async fn before<'a>(
+        &self,
+        context: &HookContext<'a>,
+        hints: Option<&'a HookHints>,
+    ) -> Result<Option<EvaluationContext>, EvaluationError>;
+
+    /// This method is called after the successful flag evaluation.
+    async fn after<'a>(
+        &self,
+        context: &HookContext<'a>,
+        details: &EvaluationDetails<Value>,
+        hints: Option<&'a HookHints>,
+    ) -> Result<(), EvaluationError>;
+
+    /// This method is called on error during flag evaluation or error in before hook or after hook.
+    async fn error<'a>(
+        &self,
+        context: &HookContext<'a>,
+        error: &EvaluationError,
+        hints: Option<&'a HookHints>,
+    );
+
+    /// This method is called after the flag evaluation, regardless of the result.
+    async fn finally<'a>(&self, context: &HookContext<'a>, hints: Option<&'a HookHints>);
+}
+
+// ============================================================
+//  HookWrapper
+// ============================================================
+
+#[allow(missing_docs)]
+#[derive(Clone)]
+pub struct HookWrapper(Arc<dyn Hook>);
+
+impl HookWrapper {
+    #[allow(missing_docs)]
+    pub fn new(hook: impl Hook) -> Self {
+        Self(Arc::new(hook))
+    }
+}
+
+impl Deref for HookWrapper {
+    type Target = dyn Hook;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+// ============================================================
+//  HookHints
+// ============================================================
+
+#[allow(missing_docs)]
+#[derive(Clone, Default, PartialEq, Debug)]
+pub struct HookHints {
+    hints: HashMap<String, Value>,
+}
+
+// ============================================================
+//  HookContext
+// ============================================================
+
+/// Context for hooks.
+#[allow(missing_docs)]
+#[derive(Clone, PartialEq, Debug)]
+pub struct HookContext<'a> {
+    pub flag_key: &'a str,
+    pub flag_type: Type,
+    pub evaluation_context: &'a EvaluationContext,
+    pub default_value: Option<Value>,
+    pub client_metadata: ClientMetadata,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use spec::spec;
+
+    use crate::{
+        provider::{MockFeatureProvider, ResolutionDetails},
+        EvaluationErrorCode, EvaluationOptions, OpenFeature, StructValue,
+    };
+
+    use super::*;
+
+    #[spec(
+        number = "4.1.1",
+        text = "Hook context MUST provide: the flag key, flag value type, evaluation context, and the default value."
+    )]
+    #[spec(
+        number = "4.1.2",
+        text = "The hook context SHOULD provide: access to the client metadata and the provider metadata fields."
+    )]
+    #[spec(
+        number = "4.1.3",
+        text = "The flag key, flag type, and default value properties MUST be immutable. If the language does not support immutability, the hook MUST NOT modify these properties."
+    )]
+    #[test]
+    fn hook_context() {
+        let context = HookContext {
+            flag_key: "flag_key",
+            flag_type: Type::Bool,
+            evaluation_context: &EvaluationContext::default(),
+            default_value: Some(Value::Bool(true)),
+            client_metadata: ClientMetadata::default(),
+        };
+
+        assert_eq!(context.flag_key, "flag_key");
+        assert_eq!(context.flag_type, Type::Bool);
+        assert_eq!(context.evaluation_context, &EvaluationContext::default());
+        assert_eq!(context.default_value, Some(Value::Bool(true)));
+        assert_eq!(context.client_metadata, ClientMetadata::default());
+    }
+
+    #[spec(
+        number = "4.2.1",
+        text = "hook hints MUST be a structure supports definition of arbitrary properties, with keys of type string, and values of type boolean | string | number | datetime | structure."
+    )]
+    #[test]
+    fn hook_hints() {
+        let mut hints = HookHints::default();
+        hints.hints.insert("key".to_string(), Value::Bool(true));
+        hints
+            .hints
+            .insert("key2".to_string(), Value::String("value".to_string()));
+        hints.hints.insert("key3".to_string(), Value::Int(42));
+        hints.hints.insert("key4".to_string(), Value::Float(3.14));
+        hints.hints.insert("key5".to_string(), Value::Array(vec![]));
+        hints
+            .hints
+            .insert("key6".to_string(), Value::Struct(StructValue::default()));
+
+        assert_eq!(hints.hints.len(), 6);
+        assert_eq!(hints.hints.get("key"), Some(&Value::Bool(true)));
+        assert_eq!(
+            hints.hints.get("key2"),
+            Some(&Value::String("value".to_string()))
+        );
+        assert_eq!(hints.hints.get("key3"), Some(&Value::Int(42)));
+        assert_eq!(hints.hints.get("key4"), Some(&Value::Float(3.14)));
+        assert_eq!(hints.hints.get("key5"), Some(&Value::Array(vec![])));
+        assert_eq!(
+            hints.hints.get("key6"),
+            Some(&Value::Struct(StructValue::default()))
+        );
+    }
+
+    #[spec(number = "4.2.2.1", text = "Hook hints MUST be immutable.")]
+    #[test]
+    fn hook_hints_mutability_checked_by_type_system() {}
+
+    #[spec(
+        number = "4.2.2.2",
+        text = "The client metadata field in the hook context MUST be immutable."
+    )]
+    #[test]
+    fn client_metadata_mutability_checked_by_type_system() {}
+
+    #[spec(
+        number = "4.2.2.3",
+        text = "The provider metadata field in the hook context MUST be immutable."
+    )]
+    #[test]
+    fn provider_metadata_mutability_checked_by_type_system() {}
+
+    #[spec(number = "4.3.1", text = "Hooks MUST specify at least one stage.")]
+    #[test]
+    fn hook_interface_implementation_checked_by_type_system() {}
+
+    #[spec(
+        number = "4.3.2.1",
+        text = "The before stage MUST run before flag resolution occurs. It accepts a hook context (required) and hook hints (optional) as parameters and returns either an evaluation context or nothing."
+    )]
+    #[test]
+    fn hook_before_function_interface_implementation_checked_by_type_system() {}
+
+    #[spec(
+        number = "4.3.4",
+        text = "Any evaluation context returned from a before hook MUST be passed to subsequent before hooks (via HookContext)."
+    )]
+    #[tokio::test]
+    async fn before_hook_context_passing() {
+        let mut mock_hook_1 = MockHook::new();
+        let mut mock_hook_2 = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        let mut client = api.create_named_client("test");
+        let mut mock_provider = MockFeatureProvider::default();
+
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        let flag_key = "flag";
+
+        let eval_ctx = EvaluationContext::default().with_custom_field("is", "a test");
+
+        let expected_eval_ctx = eval_ctx.clone();
+        let client_metadata = client.metadata().clone();
+        mock_hook_1
+            .expect_before()
+            .withf(move |ctx, _| {
+                let hook_ctx_1 = HookContext {
+                    flag_key,
+                    flag_type: Type::Bool,
+                    evaluation_context: &expected_eval_ctx,
+                    default_value: Some(Value::Bool(false)),
+                    client_metadata: client_metadata.clone(),
+                };
+
+                assert_eq!(ctx, &hook_ctx_1);
+                true
+            })
+            .once()
+            .returning(move |_, _| {
+                Ok(Some(
+                    EvaluationContext::default().with_targeting_key("mock_hook_1"),
+                ))
+            });
+
+        let expected_eval_ctx_2 = eval_ctx.clone().with_targeting_key("mock_hook_1");
+        let client_metadata = client.metadata().clone();
+        mock_hook_2
+            .expect_before()
+            .withf(move |ctx, _| {
+                let hook_ctx_1 = HookContext {
+                    flag_key,
+                    flag_type: Type::Bool,
+                    evaluation_context: &expected_eval_ctx_2,
+                    default_value: Some(Value::Bool(false)),
+                    client_metadata: client_metadata.clone(),
+                };
+
+                assert_eq!(ctx, &hook_ctx_1);
+                true
+            })
+            .once()
+            .returning(move |_, _| Ok(None));
+
+        mock_hook_1.expect_after().return_const(Ok(()));
+        mock_hook_2.expect_after().return_const(Ok(()));
+        mock_hook_1.expect_finally().return_const(());
+        mock_hook_2.expect_finally().return_const(());
+
+        // evaluation
+        client = client.with_hook(mock_hook_1).with_hook(mock_hook_2);
+
+        let result = client.get_bool_value(flag_key, Some(&eval_ctx), None).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[spec(
+        number = "4.3.5",
+        text = "When before hooks have finished executing, any resulting evaluation context MUST be merged with the existing evaluation context."
+    )]
+    #[tokio::test]
+    async fn before_hook_context_merging() {
+        let mut mock_hook = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        api.set_evaluation_context(
+            EvaluationContext::default()
+                .with_custom_field("key", "api context")
+                .with_custom_field("lowestPriority", true),
+        )
+        .await;
+
+        let mut client = api.create_named_client("test");
+        client.set_evaluation_context(
+            EvaluationContext::default()
+                .with_custom_field("key", "client context")
+                .with_custom_field("lowestPriority", false)
+                .with_custom_field("beatsClient", false),
+        );
+
+        mock_hook.expect_before().once().returning(move |_, _| {
+            Ok(Some(
+                EvaluationContext::default()
+                    .with_custom_field("key", "hook value")
+                    .with_custom_field("multiplier", 3),
+            ))
+        });
+
+        mock_hook.expect_after().return_const(Ok(()));
+        mock_hook.expect_finally().return_const(());
+
+        let flag_key = "flag";
+        let eval_ctx = EvaluationContext::default()
+            .with_custom_field("key", "invocation context")
+            .with_custom_field("on", true)
+            .with_custom_field("beatsClient", true);
+
+        let expected_ctx = EvaluationContext::default()
+            .with_custom_field("key", "hook value")
+            .with_custom_field("multiplier", 3)
+            .with_custom_field("on", true)
+            .with_custom_field("lowestPriority", false)
+            .with_custom_field("beatsClient", true);
+
+        let mut mock_provider = MockFeatureProvider::default();
+
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_resolve_string_value()
+            .withf(move |_, ctx| {
+                assert_eq!(ctx, &expected_ctx);
+                true
+            })
+            .return_const(Ok(ResolutionDetails::new("value")));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        client = client.with_hook(mock_hook);
+
+        let result = client
+            .get_string_value(flag_key, Some(&eval_ctx), None)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[spec(
+        number = "4.3.6",
+        text = "The after stage MUST run after flag resolution occurs. It accepts a hook context (required), evaluation details (required) and hook hints (optional). It has no return value."
+    )]
+    #[tokio::test]
+    async fn after_hook() {
+        let mut mock_hook = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        let mut client = api.create_client();
+        let mut mock_provider = MockFeatureProvider::default();
+
+        let mut seq = mockall::Sequence::new();
+
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_resolve_bool_value()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        mock_hook.expect_before().returning(|_, _| Ok(None));
+
+        mock_hook
+            .expect_after()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Ok(()));
+
+        mock_hook.expect_finally().return_const(());
+
+        // evaluation
+        client = client.with_hook(mock_hook);
+
+        let flag_key = "flag";
+        let eval_ctx = EvaluationContext::default().with_custom_field("is", "a test");
+
+        let result = client.get_bool_value(flag_key, Some(&eval_ctx), None).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[spec(
+        number = "4.3.7",
+        text = "The error hook MUST run when errors are encountered in the before stage, the after stage or during flag resolution. It accepts hook context (required), exception representing what went wrong (required), and hook hints (optional). It has no return value."
+    )]
+    #[tokio::test]
+    async fn error_hook() {
+        // error on `before` hook
+        {
+            let mut mock_hook = MockHook::new();
+
+            let mut api = OpenFeature::singleton_mut().await;
+            let mut client = api.create_client();
+            let mut mock_provider = MockFeatureProvider::default();
+
+            let mut seq = mockall::Sequence::new();
+
+            mock_provider.expect_hooks().return_const(vec![]);
+            mock_provider.expect_initialize().return_const(());
+            mock_provider.expect_resolve_bool_value().never();
+
+            api.set_provider(mock_provider).await;
+            drop(api);
+
+            mock_hook.expect_before().returning(|_, _| error());
+
+            mock_hook
+                .expect_error()
+                .once()
+                .in_sequence(&mut seq)
+                .return_const(());
+
+            mock_hook.expect_finally().return_const(());
+
+            // evaluation
+            client = client.with_hook(mock_hook);
+
+            let flag_key = "flag";
+            let eval_ctx = EvaluationContext::default().with_custom_field("is", "a test");
+
+            let result = client.get_bool_value(flag_key, Some(&eval_ctx), None).await;
+
+            assert!(result.is_err());
+        }
+
+        // error on evaluation
+        {
+            let mut mock_hook = MockHook::new();
+
+            let mut api = OpenFeature::singleton_mut().await;
+            let mut client = api.create_client();
+            let mut mock_provider = MockFeatureProvider::default();
+
+            let mut seq = mockall::Sequence::new();
+
+            mock_provider.expect_hooks().return_const(vec![]);
+            mock_provider.expect_initialize().return_const(());
+
+            mock_hook.expect_before().returning(|_, _| Ok(None));
+
+            mock_provider
+                .expect_resolve_bool_value()
+                .once()
+                .in_sequence(&mut seq)
+                .return_const(error());
+
+            mock_hook
+                .expect_error()
+                .once()
+                .in_sequence(&mut seq)
+                .return_const(());
+
+            mock_hook.expect_finally().return_const(());
+
+            api.set_provider(mock_provider).await;
+            drop(api);
+
+            // evaluation
+            client = client.with_hook(mock_hook);
+
+            let flag_key = "flag";
+            let eval_ctx = EvaluationContext::default().with_custom_field("is", "a test");
+
+            let result = client.get_bool_value(flag_key, Some(&eval_ctx), None).await;
+
+            assert!(result.is_err());
+        }
+    }
+
+    #[spec(
+        number = "4.3.8",
+        text = "The finally hook MUST run after the before, after, and error stages. It accepts a hook context (required), evaluation details (required) and hook hints (optional). It has no return value."
+    )]
+    #[tokio::test]
+    async fn finally_hook() {
+        let mut mock_hook = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        let mut client = api.create_client();
+        let mut mock_provider = MockFeatureProvider::default();
+
+        let mut seq = mockall::Sequence::new();
+
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        mock_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| Ok(None));
+        mock_hook
+            .expect_after()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Ok(()));
+
+        mock_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(());
+
+        // evaluation
+        client = client.with_hook(mock_hook);
+
+        let flag_key = "flag";
+        let eval_ctx = EvaluationContext::default().with_custom_field("is", "a test");
+
+        let result = client.get_bool_value(flag_key, Some(&eval_ctx), None).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[spec(
+        number = "4.4.1",
+        text = "The API, Client, Provider, and invocation MUST have a method for registering hooks."
+    )]
+    #[spec(
+        number = "4.4.2",
+        text = "Hooks MUST be evaluated in the following order -> before: API, Client, Invocation, Provider. after: Provider, Invocation, Client, API. error(if applicable): Provider, Invocation, Client, API. finally: Provider, Invocation, Client, API."
+    )]
+    #[tokio::test]
+    async fn hook_evaluation_order() {
+        let mut mock_api_hook = MockHook::new();
+        let mut mock_client_hook = MockHook::new();
+        let mut mock_provider_hook = MockHook::new();
+        let mut mock_invocation_hook = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        let mut client = api.create_client();
+        let mut provider = MockFeatureProvider::default();
+
+        let mut seq = mockall::Sequence::new();
+
+        // before: API, Client, Invocation, Provider
+        mock_api_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| Ok(None));
+        mock_client_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| Ok(None));
+        mock_invocation_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| Ok(None));
+        mock_provider_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| Ok(None));
+
+        // evaluation
+        provider
+            .expect_resolve_bool_value()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        // after: Provider, Invocation, Client, API
+        mock_provider_hook
+            .expect_after()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| Ok(()));
+        mock_invocation_hook
+            .expect_after()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| Ok(()));
+        mock_client_hook
+            .expect_after()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| Ok(()));
+        mock_api_hook
+            .expect_after()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| Ok(()));
+
+        // finally: Provider, Invocation, Client, API
+        mock_provider_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+        mock_invocation_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+        mock_client_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+        mock_api_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+
+        provider
+            .expect_hooks()
+            .return_const(vec![HookWrapper::new(mock_provider_hook)]);
+        provider.expect_initialize().return_const(());
+
+        api.set_provider(provider).await;
+        api.add_hook(mock_api_hook).await;
+        client = client.with_hook(mock_client_hook);
+
+        let eval = EvaluationOptions::default().with_hook(mock_invocation_hook);
+        let _ = client.get_bool_value("flag", None, Some(&eval)).await;
+    }
+
+    #[spec(
+        number = "4.4.3",
+        text = "If a finally hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining finally hooks."
+    )]
+    #[test]
+    fn finally_hook_not_throw_checked_by_type_system() {}
+
+    #[spec(
+        number = "4.4.4",
+        text = "If an error hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining error hooks."
+    )]
+    #[test]
+    fn error_hook_not_throw_checked_by_type_system() {}
+
+    #[spec(
+        number = "4.4.5",
+        text = "If an error occurs in the before or after hooks, the error hooks MUST be invoked."
+    )]
+    #[tokio::test]
+    async fn error_hook_invoked_on_error() {
+        let mut mock_hook = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        let mut client = api.create_client();
+        let mut mock_provider = MockFeatureProvider::default();
+
+        let mut seq = mockall::Sequence::new();
+
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider.expect_resolve_bool_value().never();
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        mock_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| error());
+
+        mock_hook
+            .expect_error()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(());
+
+        mock_hook.expect_finally().return_const(());
+
+        // evaluation
+        client = client.with_hook(mock_hook);
+
+        let flag_key = "flag";
+        let eval_ctx = EvaluationContext::default().with_custom_field("is", "a test");
+
+        let result = client.get_bool_value(flag_key, Some(&eval_ctx), None).await;
+
+        assert!(result.is_err());
+    }
+
+    #[spec(
+        number = "4.4.6",
+        text = "If an error occurs during the evaluation of before or after hooks, any remaining hooks in the before or after stages MUST NOT be invoked."
+    )]
+    #[tokio::test]
+    async fn do_not_evaluate_remaining_hooks_on_error() {
+        let mut mock_api_hook = MockHook::new();
+        let mut mock_client_hook = MockHook::new();
+        let mut mock_provider_hook = MockHook::new();
+        let mut mock_invocation_hook = MockHook::new();
+
+        let mut api = OpenFeature::singleton_mut().await;
+        let mut client = api.create_client();
+        let mut provider = MockFeatureProvider::default();
+
+        let mut seq = mockall::Sequence::new();
+
+        // before: API, Client, Invocation, Provider
+        mock_api_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| Ok(None));
+        mock_client_hook
+            .expect_before()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| error());
+
+        // Remaining `before` and `after` hooks should not be called
+        mock_invocation_hook.expect_before().never();
+        mock_provider_hook.expect_before().never();
+
+        // evaluation should not be called
+        provider.expect_resolve_bool_value().never();
+
+        // after: Provider, Invocation, Client, API
+        mock_provider_hook.expect_after().never();
+        mock_invocation_hook.expect_after().never();
+        mock_client_hook.expect_after().never();
+        mock_api_hook.expect_after().never();
+
+        // error: Provider, Invocation, Client, API
+        mock_provider_hook
+            .expect_error()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| {});
+        mock_invocation_hook
+            .expect_error()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| {});
+        mock_client_hook
+            .expect_error()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| {});
+        mock_api_hook
+            .expect_error()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _| {});
+
+        // finally: Provider, Invocation, Client, API
+        mock_provider_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+        mock_invocation_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+        mock_client_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+        mock_api_hook
+            .expect_finally()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| {});
+
+        provider
+            .expect_hooks()
+            .return_const(vec![HookWrapper::new(mock_provider_hook)]);
+        provider.expect_initialize().return_const(());
+
+        api.set_provider(provider).await;
+        api.add_hook(mock_api_hook).await;
+        client = client.with_hook(mock_client_hook);
+
+        let eval = EvaluationOptions::default().with_hook(mock_invocation_hook);
+        let result = client.get_bool_value("flag", None, Some(&eval)).await;
+
+        assert!(result.is_err());
+    }
+
+    #[spec(
+        number = "4.4.7",
+        text = "If an error occurs in the before hooks, the default value MUST be returned."
+    )]
+    #[test]
+    fn default_value_covered_by_implementing_default_trait() {}
+
+    fn error<T>() -> Result<T, EvaluationError> {
+        Err(EvaluationError {
+            code: EvaluationErrorCode::General("error".to_string()),
+            message: None,
+        })
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
-use crate::{ClientMetadata, EvaluationContext, EvaluationDetails, EvaluationError, Type, Value};
+use crate::{
+    provider::ProviderMetadata, ClientMetadata, EvaluationContext, EvaluationDetails,
+    EvaluationError, Type, Value,
+};
 
 mod logging;
 pub use logging::LoggingHook;
@@ -96,6 +99,7 @@ pub struct HookContext<'a> {
     pub flag_key: &'a str,
     pub flag_type: Type,
     pub evaluation_context: &'a EvaluationContext,
+    pub provider_metadata: ProviderMetadata,
     pub default_value: Option<Value>,
     pub client_metadata: ClientMetadata,
 }
@@ -130,6 +134,7 @@ mod tests {
             flag_key: "flag_key",
             flag_type: Type::Bool,
             evaluation_context: &EvaluationContext::default(),
+            provider_metadata: ProviderMetadata::default(),
             default_value: Some(Value::Bool(true)),
             client_metadata: ClientMetadata::default(),
         };
@@ -137,6 +142,7 @@ mod tests {
         assert_eq!(context.flag_key, "flag_key");
         assert_eq!(context.flag_type, Type::Bool);
         assert_eq!(context.evaluation_context, &EvaluationContext::default());
+        assert_eq!(context.provider_metadata, ProviderMetadata::default());
         assert_eq!(context.default_value, Some(Value::Bool(true)));
         assert_eq!(context.client_metadata, ClientMetadata::default());
     }
@@ -219,6 +225,9 @@ mod tests {
         mock_provider.expect_hooks().return_const(vec![]);
         mock_provider.expect_initialize().return_const(());
         mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        mock_provider
             .expect_resolve_bool_value()
             .withf(|_, ctx| {
                 assert_eq!(
@@ -248,6 +257,7 @@ mod tests {
                     flag_type: Type::Bool,
                     evaluation_context: &expected_eval_ctx,
                     default_value: Some(Value::Bool(false)),
+                    provider_metadata: ProviderMetadata::default(),
                     client_metadata: client_metadata.clone(),
                 };
 
@@ -271,6 +281,7 @@ mod tests {
                     flag_type: Type::Bool,
                     evaluation_context: &expected_eval_ctx_2,
                     default_value: Some(Value::Bool(false)),
+                    provider_metadata: ProviderMetadata::default(),
                     client_metadata: client_metadata.clone(),
                 };
 
@@ -346,6 +357,9 @@ mod tests {
         mock_provider.expect_hooks().return_const(vec![]);
         mock_provider.expect_initialize().return_const(());
         mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        mock_provider
             .expect_resolve_string_value()
             .withf(move |_, ctx| {
                 assert_eq!(ctx, &expected_ctx);
@@ -381,6 +395,9 @@ mod tests {
 
         mock_provider.expect_hooks().return_const(vec![]);
         mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
         mock_provider
             .expect_resolve_bool_value()
             .once()
@@ -430,6 +447,9 @@ mod tests {
             mock_provider.expect_hooks().return_const(vec![]);
             mock_provider.expect_initialize().return_const(());
             mock_provider.expect_resolve_bool_value().never();
+            mock_provider
+                .expect_metadata()
+                .return_const(ProviderMetadata::default());
 
             api.set_provider(mock_provider).await;
             drop(api);
@@ -482,6 +502,9 @@ mod tests {
 
             mock_provider.expect_hooks().return_const(vec![]);
             mock_provider.expect_initialize().return_const(());
+            mock_provider
+                .expect_metadata()
+                .return_const(ProviderMetadata::default());
 
             mock_hook.expect_before().returning(|_, _| Ok(None));
 
@@ -530,6 +553,9 @@ mod tests {
 
         mock_provider.expect_hooks().return_const(vec![]);
         mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
         mock_provider
             .expect_resolve_bool_value()
             .return_const(Ok(ResolutionDetails::new(true)));
@@ -674,6 +700,9 @@ mod tests {
             .expect_hooks()
             .return_const(vec![HookWrapper::new(mock_provider_hook)]);
         provider.expect_initialize().return_const(());
+        provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
 
         api.set_provider(provider).await;
         api.add_hook(mock_api_hook).await;
@@ -714,6 +743,9 @@ mod tests {
         mock_provider.expect_hooks().return_const(vec![]);
         mock_provider.expect_initialize().return_const(());
         mock_provider.expect_resolve_bool_value().never();
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
 
         api.set_provider(mock_provider).await;
 
@@ -832,6 +864,9 @@ mod tests {
             .expect_hooks()
             .return_const(vec![HookWrapper::new(mock_provider_hook)]);
         provider.expect_initialize().return_const(());
+        provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
 
         api.set_provider(provider).await;
         api.add_hook(mock_api_hook).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ pub use api::*;
 mod evaluation;
 pub use evaluation::*;
 
+/// Hooks related.
+mod hooks;
+pub use hooks::*;
+
 /// Feature provider related.
 pub mod provider;
 pub use async_trait::async_trait;

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -96,7 +96,7 @@ pub trait FeatureProvider: Send + Sync + 'static {
 // ============================================================
 
 /// The metadata of a feature provider.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub struct ProviderMetadata {
     /// The name of provider.
     pub name: String,

--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -49,6 +49,12 @@ pub trait FeatureProvider: Send + Sync + 'static {
     /// or accessor of type string, which identifies the provider implementation.
     fn metadata(&self) -> &ProviderMetadata;
 
+    /// The provider MAY define a hooks field or accessor which returns a list of hooks that
+    /// the provider supports.
+    fn hooks(&self) -> &[crate::hooks::HookWrapper] {
+        &[]
+    }
+
     /// Resolve given `flag_key` as a bool value.
     async fn resolve_bool_value(
         &self,

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -20,7 +20,7 @@ fn json_value_to_value(value: &serde_json::Value) -> EvaluationResult<Value> {
     match value {
         serde_json::Value::Bool(value) => Ok(Value::Bool(*value)),
         serde_json::Value::Number(value) if value.is_i64() => {
-            Ok(Value::Int(value.as_i64().unwrap())) //TODO: remove unwrap or use expect
+            Ok(Value::Int(value.as_i64().unwrap()))
         }
         serde_json::Value::Number(value) if value.is_f64() => {
             Ok(Value::Float(value.as_f64().unwrap()))

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -20,7 +20,7 @@ fn json_value_to_value(value: &serde_json::Value) -> EvaluationResult<Value> {
     match value {
         serde_json::Value::Bool(value) => Ok(Value::Bool(*value)),
         serde_json::Value::Number(value) if value.is_i64() => {
-            Ok(Value::Int(value.as_i64().unwrap()))
+            Ok(Value::Int(value.as_i64().unwrap())) //TODO: remove unwrap or use expect
         }
         serde_json::Value::Number(value) if value.is_f64() => {
             Ok(Value::Float(value.as_f64().unwrap()))


### PR DESCRIPTION
## This PR
This pull request introduces the implementation of Hooks in the OpenFeature SDK following the OpenFeature standard. The changes include the addition of hooks to various stages in the feature flag evaluation process, such as before, after, error, and finally. The implementation provides capabilities to add hooks at the global, client, provider, and invocation levels, which allows for extensive customizability and control over the feature flag lifecycle.

- Adds hooks to support the OpenFeature specification for flag evaluation.
- Implements the capability to register hooks at various levels including global, client, provider, and invocation.
- Introduces logging for lifecycle events using hooks.
- Provides test cases for the new hooks capability to ensure compliance with the OpenFeature specification.

### Related Issues
Fixes #5 

### Notes
- Make sure logging is appropriately configured in the consuming application to take advantage of the logging hooks.
- This implementation supports extensibility for additional hooks in the future by following the standardized hook interface.

### Follow-up Tasks
- Consider implementing example hooks that demonstrate different use cases, like metrics collection or error reporting.
- Evaluate if default hooks should be provided in the SDK for common use cases.

### How to test
1. Build and run the example included in `examples/hooks.rs` to see a working implementation of the hooks in action.
2. Review test cases provided in `src/hooks/mod.rs` to ensure they cover expected behaviors and edge cases.
3. Ensure that the hooks are called in the correct order and can handle errors gracefully.
