### PR TITLE
build: reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 async-trait = "0.1.80"
-lazy_static = "1.5"
 mockall = { version = "0.13.0", optional = true }
 serde_json = { version = "1.0.116", optional = true }
 time = "0.3.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.5"
 mockall = { version = "0.13.0", optional = true }
 serde_json = { version = "1.0.116", optional = true }
 time = "0.3.36"
-tokio = { version = "1.40", features = ["full"] }
+tokio = { version = "1.40", features = ["sync"] }
 typed-builder = "0.22.0"
 
 log = { package = "log", version = "0.4", optional = true }
@@ -30,6 +30,7 @@ log = { package = "log", version = "0.4", optional = true }
 env_logger = "0.11.5"
 structured-logger = "1.0.3"
 spec = { path = "spec" }
+tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["test-util", "dep:log"]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -622,10 +622,7 @@ mod tests {
 
         let client = create_client(provider).await;
 
-        assert_eq!(
-            client.get_bool_value("key", None, None).await.unwrap(),
-            true
-        );
+        assert!(client.get_bool_value("key", None, None).await.unwrap());
 
         assert_eq!(client.get_int_value("key", None, None).await.unwrap(), 123);
 

--- a/src/evaluation/context.rs
+++ b/src/evaluation/context.rs
@@ -95,7 +95,7 @@ mod tests {
     fn merge_missing_given_targeting_key() {
         let mut context = EvaluationContext::default()
             .with_targeting_key("Targeting Key")
-            .to_owned();
+            .clone();
 
         let expected = context.clone();
 
@@ -122,7 +122,7 @@ mod tests {
                 .with_targeting_key("Targeting Key")
                 .with_custom_field("Key", "Value")
                 .with_custom_field("Another Key", "Value")
-        )
+        );
     }
 
     #[test]

--- a/src/evaluation/context_field_value.rs
+++ b/src/evaluation/context_field_value.rs
@@ -228,7 +228,7 @@ mod tests {
             .with_custom_field("Int", 42)
             .with_custom_field("Float", 42.0)
             .with_custom_field("String", "StringValue")
-            .with_custom_field("DateTime", now.clone())
+            .with_custom_field("DateTime", now)
             .with_custom_field(
                 "Struct",
                 EvaluationContextFieldValue::new_struct(EvaluationReason::Cached),
@@ -237,7 +237,7 @@ mod tests {
         // Assert bool
         if let EvaluationContextFieldValue::Bool(value) = context.custom_fields.get("Bool").unwrap()
         {
-            assert_eq!(true, *value);
+            assert!(*value);
         } else {
             panic!()
         }
@@ -284,6 +284,6 @@ mod tests {
             assert_eq!(EvaluationReason::Cached, *v);
         } else {
             panic!()
-        };
+        }
     }
 }

--- a/src/evaluation/value.rs
+++ b/src/evaluation/value.rs
@@ -258,7 +258,7 @@ mod tests {
 
         let is_male = alex.fields.get("is_male").unwrap();
         assert!(is_male.is_bool());
-        assert_eq!(false, is_male.as_bool().unwrap());
+        assert!(!is_male.as_bool().unwrap());
 
         let id = alex.fields.get("id").unwrap();
         assert!(id.is_i64());

--- a/src/hooks/logging.rs
+++ b/src/hooks/logging.rs
@@ -102,7 +102,7 @@ impl LoggingHook {
 
 #[cfg(feature = "structured-logging")]
 mod structured {
-    use super::{LoggingHook, HookContext, EvaluationDetails, Value, EvaluationError};
+    use super::{EvaluationDetails, EvaluationError, HookContext, LoggingHook, Value};
     use log::{kv::Value as LogValue, Level, Record};
 
     const DOMAIN_KEY: &str = "domain";

--- a/src/hooks/logging.rs
+++ b/src/hooks/logging.rs
@@ -102,7 +102,7 @@ impl LoggingHook {
 
 #[cfg(feature = "structured-logging")]
 mod structured {
-    use super::*;
+    use super::{LoggingHook, HookContext, EvaluationDetails, Value, EvaluationError};
     use log::{kv::Value as LogValue, Level, Record};
 
     const DOMAIN_KEY: &str = "domain";
@@ -154,7 +154,7 @@ mod structured {
             // See issue https://github.com/rust-lang/rust/issues/92698
             log::logger().log(
                 &Record::builder()
-                    .args(format_args!("{}", msg))
+                    .args(format_args!("{msg}"))
                     .level(level)
                     .target("open_feature")
                     .module_path_static(Some(module_path!()))
@@ -188,9 +188,9 @@ mod structured {
         }
     }
 
-    fn evaluation_details_to_kvs<'a>(
-        details: &'a EvaluationDetails<Value>,
-    ) -> Vec<(&'static str, LogValue<'a>)> {
+    fn evaluation_details_to_kvs(
+        details: &EvaluationDetails<Value>,
+    ) -> Vec<(&'static str, LogValue<'_>)> {
         let kvs = vec![
             (REASON_KEY, LogValue::from_debug(&details.reason)),
             (VARIANT_KEY, LogValue::from_debug(&details.variant)),
@@ -200,7 +200,7 @@ mod structured {
         kvs
     }
 
-    fn error_to_kvs<'a>(error: &'a EvaluationError) -> Vec<(&'static str, LogValue<'a>)> {
+    fn error_to_kvs(error: &EvaluationError) -> Vec<(&'static str, LogValue<'_>)> {
         let kvs = vec![(ERROR_MESSAGE_KEY, LogValue::from_debug(&error.message))];
 
         kvs

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -29,7 +29,7 @@ fn json_value_to_value(value: &serde_json::Value) -> EvaluationResult<Value> {
         serde_json::Value::Array(array) => Ok(Value::Array(
             array
                 .iter()
-                .map(|x| json_value_to_value(x))
+                .map(json_value_to_value)
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         serde_json::Value::Object(object) => {


### PR DESCRIPTION
Unnecessary features of tokio were removed.

Removes `lazy_static` since the same functionality is now available on stable.