### PR TITLE
fix: Shutdown calls providers' shutdown 

### DIFF
--- a/src/provider/feature_provider.rs
+++ b/src/provider/feature_provider.rs
@@ -45,6 +45,10 @@ pub trait FeatureProvider: Send + Sync + 'static {
         ProviderStatus::Ready
     }
 
+    /// The provider MAY define a mechanism to gracefully shutdown and dispose of resources.
+    #[allow(unused_variables)]
+    async fn shutdown(&self) {}
+
     /// The provider interface MUST define a metadata member or accessor, containing a name field
     /// or accessor of type string, which identifies the provider implementation.
     fn metadata(&self) -> &ProviderMetadata;


### PR DESCRIPTION
Addressing #124.

The fix might not be that simple, if we want to execute the shutting down of providers in a background threads while leaving all the APIs available at runtime. My concern here is the possible race condition or simply operational overlap of shut downs and, for example, the in-flight evaluation operations.

Any suggestion from the Rust community is appreciated here.  