### PR TITLE
refactor!: replace lazy_static with std::sync::OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open-feature"
 version = "0.2.7"
 edition = "2021"
-rust-version = "1.77.0" # MSRV
+rust-version = "1.80.1" # MSRV
 description = "The official OpenFeature Rust SDK."
 documentation = "https://docs.rs/open-feature"
 readme = "README.md"
@@ -17,11 +17,10 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 async-trait = "0.1.80"
-lazy_static = "1.5"
 mockall = { version = "0.14.0", optional = true }
 serde_json = { version = "1.0.116", optional = true }
 time = "0.3.36"
-tokio = { version = "1.40", features = ["full"] }
+tokio = { version = "1.40", features = ["sync"] }
 typed-builder = "0.22.0"
 
 log = { package = "log", version = "0.4", optional = true }
@@ -30,6 +29,7 @@ log = { package = "log", version = "0.4", optional = true }
 env_logger = "0.11.5"
 structured-logger = "1.0.3"
 spec = { path = "spec" }
+tokio = { version = "1.40", features = ["sync", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["test-util", "dep:log"]

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -16,7 +16,7 @@ use super::{
 /// The client should always use this instance to access OpenFeature APIs.
 static SINGLETON: OnceLock<RwLock<OpenFeature>> = OnceLock::new();
 
-fn singleton_lock() -> &'static RwLock<OpenFeature> {
+fn get_singleton() -> &'static RwLock<OpenFeature> {
     SINGLETON.get_or_init(|| RwLock::new(OpenFeature::default()))
 }
 

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -33,12 +33,12 @@ pub struct OpenFeature {
 impl OpenFeature {
     /// Get the singleton of [`OpenFeature`].
     pub async fn singleton() -> RwLockReadGuard<'static, Self> {
-        singleton_lock().read().await
+        get_singleton().read().await
     }
 
     /// Get a mutable singleton of [`OpenFeature`].
     pub async fn singleton_mut() -> RwLockWriteGuard<'static, Self> {
-        singleton_lock().write().await
+        get_singleton().write().await
     }
 
     /// Set the global evaluation context.

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -1,4 +1,5 @@
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
+
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::{
@@ -11,14 +12,16 @@ use super::{
     provider_registry::ProviderRegistry,
 };
 
-lazy_static! {
-    /// The singleton instance of [`OpenFeature`] struct.
-    /// The client should always use this instance to access OpenFeature APIs.
-    static ref SINGLETON: RwLock<OpenFeature> = RwLock::new(OpenFeature::default());
+/// The singleton instance of [`OpenFeature`] struct.
+/// The client should always use this instance to access OpenFeature APIs.
+static SINGLETON: OnceLock<RwLock<OpenFeature>> = OnceLock::new();
+
+fn singleton_lock() -> &'static RwLock<OpenFeature> {
+    SINGLETON.get_or_init(|| RwLock::new(OpenFeature::default()))
 }
 
 /// THE struct of the OpenFeature API.
-/// Access it via the [`SINGLETON`] instance.
+/// Access it via [`OpenFeature::singleton()`] or [`OpenFeature::singleton_mut()`].
 #[derive(Default)]
 pub struct OpenFeature {
     evaluation_context: GlobalEvaluationContext,
@@ -30,12 +33,12 @@ pub struct OpenFeature {
 impl OpenFeature {
     /// Get the singleton of [`OpenFeature`].
     pub async fn singleton() -> RwLockReadGuard<'static, Self> {
-        SINGLETON.read().await
+        singleton_lock().read().await
     }
 
     /// Get a mutable singleton of [`OpenFeature`].
     pub async fn singleton_mut() -> RwLockWriteGuard<'static, Self> {
-        SINGLETON.write().await
+        singleton_lock().write().await
     }
 
     /// Set the global evaluation context.


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This change enables Webassembly compatibility by replacing `lazy_static` with `syd::sync:OnceLock` and tokio feature changes. It should be considered breaking due MSRV change.

This change doesn't have any performance impact on the library itself. tokio's `sync` feature provides `RwLock` which works identically regardless of runtime. Users of this library can enable tokio's multi-threaded runtime if needed.

Changes in summary:
- Replace lazy_static crate with std::sync::OnceLock for singleton
- Bump MSRV from 1.77.0 to 1.80.1
- Remove lazy_static dependency
- Split tokio features: sync for library, rt-multi-thread/macros for tests
- Update doc comment to reference public API methods

### Related Issues
This change is the first follow up from comments over [Slack](https://cloud-native.slack.com/archives/C03J36ZP020/p1771624450568139) regarding web assembly compatibility requests
