### PR TITLE
feat!: implement HookData 

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,52 @@ To run the example, execute the following command:
 cargo run --example hooks
 ```
 
+#### Hook data
+
+A hook can carry state across its own stages within a single evaluation via `context.data`.
+Each hook instance gets its own `HookData`, shared across that hook's `before`, `after`, `error`, and `finally`
+stages and isolated from every other hook. This is the recommended place to stash state such as a start
+timestamp or a telemetry span opened in `before` and consumed in `after`/`finally`.
+A fresh `HookData` is created for every evaluation, so a hook instance registered once on a client and
+reused across evaluations never observes state left over from a previous one.
+
+```rust
+#[async_trait::async_trait]
+impl Hook for TimingHook {
+    async fn before<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _hints: Option<&'a HookHints>,
+    ) -> Result<Option<EvaluationContext>, EvaluationError> {
+        // Store any `'static + Send + Sync` value; not limited to the `Value` types.
+        context.data.set("start_time", std::time::Instant::now());
+        Ok(None)
+    }
+
+    async fn finally<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _details: &EvaluationDetails<Value>,
+        _hints: Option<&'a HookHints>,
+    ) {
+        // `take` moves the value out without requiring it to be `Clone`.
+        if let Some(start) = context.data.take::<std::time::Instant>("start_time") {
+            log::info!("Evaluated {} in {:?}", context.flag_key, start.elapsed());
+        }
+    }
+
+    // `after` and `error` omitted for brevity.
+}
+```
+
+Example of hook data usage you can find in [examples/hook_data.rs](https://github.com/open-feature/rust-sdk/blob/main/examples/hook_data.rs).
+
+To run the example, execute the following command:
+
+```shell
+cargo run --example hook_data
+```
+
 ### Logging
 
 Note that in accordance with the OpenFeature specification, the SDK doesn't generally log messages during flag evaluation.

--- a/examples/hook_data.rs
+++ b/examples/hook_data.rs
@@ -1,0 +1,150 @@
+//! Demonstrates hook data: a timing hook that records a start instant in the `before` stage and
+//! reads it back in `finally` to report how long the evaluation took.
+//!
+//! Hook data is isolated per hook instance and shared across that hook's stages for a single
+//! evaluation, which makes it the right place to stash state like a timer or a telemetry span.
+//!
+//! Run with: `cargo run --example hook_data`
+
+use std::time::Instant;
+
+use open_feature::{
+    provider::{FeatureProvider, ProviderMetadata, ProviderStatus, ResolutionDetails},
+    EvaluationContext, EvaluationDetails, EvaluationError, EvaluationResult, Hook, HookContext,
+    HookHints, OpenFeature, StructValue, Value,
+};
+
+struct DummyProvider(ProviderMetadata);
+
+impl Default for DummyProvider {
+    fn default() -> Self {
+        Self(ProviderMetadata::new("Dummy Provider"))
+    }
+}
+
+#[async_trait::async_trait]
+impl FeatureProvider for DummyProvider {
+    fn metadata(&self) -> &ProviderMetadata {
+        &self.0
+    }
+
+    fn status(&self) -> ProviderStatus {
+        ProviderStatus::Ready
+    }
+
+    async fn resolve_bool_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<bool>> {
+        Ok(ResolutionDetails::new(true))
+    }
+
+    async fn resolve_int_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<i64>> {
+        unimplemented!()
+    }
+
+    async fn resolve_float_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<f64>> {
+        unimplemented!()
+    }
+
+    async fn resolve_string_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> EvaluationResult<ResolutionDetails<String>> {
+        unimplemented!()
+    }
+
+    async fn resolve_struct_value(
+        &self,
+        _flag_key: &str,
+        _evaluation_context: &EvaluationContext,
+    ) -> Result<ResolutionDetails<StructValue>, EvaluationError> {
+        unimplemented!()
+    }
+}
+
+/// A hook that times how long a flag evaluation takes by storing an `Instant` in its hook data.
+struct TimingHook;
+
+const START_KEY: &str = "start_time";
+
+#[async_trait::async_trait]
+impl Hook for TimingHook {
+    async fn before<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _hints: Option<&'a HookHints>,
+    ) -> Result<Option<EvaluationContext>, EvaluationError> {
+        // Stash the start time; this hook data is private to this hook for this evaluation.
+        context.data.set(START_KEY, Instant::now());
+        Ok(None)
+    }
+
+    async fn after<'a>(
+        &self,
+        _context: &HookContext<'a>,
+        _details: &EvaluationDetails<Value>,
+        _hints: Option<&'a HookHints>,
+    ) -> Result<(), EvaluationError> {
+        Ok(())
+    }
+
+    async fn error<'a>(
+        &self,
+        _context: &HookContext<'a>,
+        _error: &EvaluationError,
+        _hints: Option<&'a HookHints>,
+    ) {
+    }
+
+    async fn finally<'a>(
+        &self,
+        context: &HookContext<'a>,
+        _evaluation_details: &EvaluationDetails<Value>,
+        _hints: Option<&'a HookHints>,
+    ) {
+        // Consume the same instant we set in `before` and report the elapsed time. `take` gives
+        // ownership without requiring the stored value to be `Clone`.
+        match context.data.take::<Instant>(START_KEY) {
+            Some(start) => log::info!(
+                "Flag '{}' evaluated in {:?}",
+                context.flag_key,
+                start.elapsed()
+            ),
+            None => log::warn!("Timing hook: no start time recorded"),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let mut api = OpenFeature::singleton_mut().await;
+    api.set_provider(DummyProvider::default()).await;
+    drop(api);
+
+    let client = OpenFeature::singleton()
+        .await
+        .create_client()
+        .with_hook(TimingHook);
+
+    let value = client
+        .get_bool_value("my_feature", None, None)
+        .await
+        .unwrap();
+
+    println!("Feature value: {value}");
+}

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -3,7 +3,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use crate::{
     provider::{FeatureProvider, ResolutionDetails},
     EvaluationContext, EvaluationDetails, EvaluationError, EvaluationErrorCode, EvaluationOptions,
-    EvaluationResult, Hook, HookContext, HookHints, HookWrapper, StructValue, Value,
+    EvaluationResult, Hook, HookContext, HookData, HookHints, HookWrapper, StructValue, Value,
 };
 
 use super::{
@@ -316,6 +316,8 @@ impl Client {
             evaluation_context: context,
 
             default_value: Some(default),
+            // Placeholder; each hook is invoked with its own isolated `HookData` (see below).
+            data: HookData::default(),
         };
 
         let global_hooks = self.global_hooks.get().await;
@@ -327,18 +329,27 @@ impl Client {
 
         // INFO: API(global), Client, Invocation, Provider
         // https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md#requirement-442
-        let before_hooks = global_hooks
+        let ordered_hooks: Vec<&HookWrapper> = global_hooks
             .iter()
             .chain(client_hooks.iter())
             .chain(invocation_hooks.iter())
-            .chain(provider_hooks.iter());
+            .chain(provider_hooks.iter())
+            .collect();
+
+        // INFO: Each hook instance gets its own `HookData`, shared across that hook's stages for
+        // this evaluation, isolated from every other hook.
+        // https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md#46-hook-data
+        let hook_data: Vec<HookData> = ordered_hooks.iter().map(|_| HookData::default()).collect();
+
+        // INFO: (hook, its data) in before order: API(global), Client, Invocation, Provider
+        let before_hooks = || ordered_hooks.iter().copied().zip(hook_data.iter());
 
         // INFO: Hooks called after the resolution are in reverse order
         // Provider, Invocation, Client, API(global)
-        let after_hooks = before_hooks.clone().rev();
+        let after_hooks = || before_hooks().rev();
 
         let (context, result) = self
-            .before_hooks(before_hooks.into_iter(), &hook_context, hints)
+            .before_hooks(before_hooks(), &hook_context, hints)
             .await;
         hook_context.evaluation_context = &context;
 
@@ -347,16 +358,11 @@ impl Client {
         let evaluation_details;
 
         if let Err(error) = result {
-            self.error_hooks(after_hooks.clone(), &hook_context, &error, hints)
+            self.error_hooks(after_hooks(), &hook_context, &error, hints)
                 .await;
             evaluation_details = EvaluationDetails::error_reason(flag_key, T::default());
-            self.finally_hooks(
-                after_hooks.into_iter(),
-                &hook_context,
-                &evaluation_details,
-                hints,
-            )
-            .await;
+            self.finally_hooks(after_hooks(), &hook_context, &evaluation_details, hints)
+                .await;
 
             return Err(error);
         }
@@ -371,11 +377,11 @@ impl Client {
             Ok(ref details) => {
                 let details = details.clone().into_value();
                 if let Err(error) = self
-                    .after_hooks(after_hooks.clone(), &hook_context, &details, hints)
+                    .after_hooks(after_hooks(), &hook_context, &details, hints)
                     .await
                 {
                     evaluation_details = EvaluationDetails::error_reason(flag_key, T::default());
-                    self.error_hooks(after_hooks.clone(), &hook_context, &error, hints)
+                    self.error_hooks(after_hooks(), &hook_context, &error, hints)
                         .await;
                 } else {
                     evaluation_details = details;
@@ -383,18 +389,13 @@ impl Client {
             }
             Err(ref error) => {
                 evaluation_details = EvaluationDetails::error_reason(flag_key, T::default());
-                self.error_hooks(after_hooks.clone(), &hook_context, error, hints)
+                self.error_hooks(after_hooks(), &hook_context, error, hints)
                     .await;
             }
         }
 
-        self.finally_hooks(
-            after_hooks.into_iter(),
-            &hook_context,
-            &evaluation_details,
-            hints,
-        )
-        .await;
+        self.finally_hooks(after_hooks(), &hook_context, &evaluation_details, hints)
+            .await;
 
         result
     }
@@ -406,12 +407,13 @@ impl Client {
         hints: Option<&HookHints>,
     ) -> (EvaluationContext, EvaluationResult<()>)
     where
-        I: Iterator<Item = &'a HookWrapper>,
+        I: Iterator<Item = (&'a HookWrapper, &'a HookData)>,
     {
         let mut context = hook_context.evaluation_context.clone();
-        for hook in hooks {
+        for (hook, data) in hooks {
             let invoke_hook_context = HookContext {
                 evaluation_context: &context,
+                data: data.clone(),
                 ..hook_context.clone()
             };
             match hook.before(&invoke_hook_context, hints).await {
@@ -437,10 +439,14 @@ impl Client {
         hints: Option<&HookHints>,
     ) -> EvaluationResult<()>
     where
-        I: Iterator<Item = &'a HookWrapper>,
+        I: Iterator<Item = (&'a HookWrapper, &'a HookData)>,
     {
-        for hook in hooks {
-            hook.after(hook_context, details, hints).await?;
+        for (hook, data) in hooks {
+            let invoke_hook_context = HookContext {
+                data: data.clone(),
+                ..hook_context.clone()
+            };
+            hook.after(&invoke_hook_context, details, hints).await?;
         }
 
         Ok(())
@@ -453,10 +459,14 @@ impl Client {
         error: &EvaluationError,
         hints: Option<&HookHints>,
     ) where
-        I: Iterator<Item = &'a HookWrapper>,
+        I: Iterator<Item = (&'a HookWrapper, &'a HookData)>,
     {
-        for hook in hooks {
-            hook.error(hook_context, error, hints).await;
+        for (hook, data) in hooks {
+            let invoke_hook_context = HookContext {
+                data: data.clone(),
+                ..hook_context.clone()
+            };
+            hook.error(&invoke_hook_context, error, hints).await;
         }
     }
 
@@ -467,10 +477,15 @@ impl Client {
         evaluation_details: &EvaluationDetails<Value>,
         hints: Option<&HookHints>,
     ) where
-        I: Iterator<Item = &'a HookWrapper>,
+        I: Iterator<Item = (&'a HookWrapper, &'a HookData)>,
     {
-        for hook in hooks {
-            hook.finally(hook_context, evaluation_details, hints).await;
+        for (hook, data) in hooks {
+            let invoke_hook_context = HookContext {
+                data: data.clone(),
+                ..hook_context.clone()
+            };
+            hook.finally(&invoke_hook_context, evaluation_details, hints)
+                .await;
         }
     }
 }

--- a/src/hooks/data.rs
+++ b/src/hooks/data.rs
@@ -1,0 +1,309 @@
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+// ============================================================
+//  HookData
+// ============================================================
+
+/// A mutable, string-keyed collection for passing arbitrary data between the stages of a single
+/// hook during a single flag evaluation.
+///
+/// Each hook instance receives its own `HookData` for the duration of one evaluation, and the same
+/// instance is shared across that hook's `before`, `after`, `error`, and `finally` stages. This
+/// lets a hook, for example, start a timer or open a telemetry span in `before` and read it back in
+/// `after`/`finally`. The data is isolated per hook: one hook can never observe another hook's data.
+///
+/// Values may be of any `'static + Send + Sync` type; they are stored type-erased and recovered via
+/// [`HookData::get`], which performs a checked downcast.
+///
+/// Cloning a `HookData` yields another handle to the *same* underlying storage (it is reference
+/// counted), which is how the SDK preserves a hook's data when the evaluation context changes
+/// between `before` hooks. Application code generally should not retain a clone beyond the hook
+/// stage in which it was received.
+///
+/// See the [specification](https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md#46-hook-data).
+#[derive(Clone, Default)]
+pub struct HookData {
+    data: Arc<Mutex<HashMap<String, Box<dyn Any + Send + Sync>>>>,
+}
+
+type Store = HashMap<String, Box<dyn Any + Send + Sync>>;
+
+impl HookData {
+    /// Create an empty [`HookData`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Lock the inner map, recovering the guard even if a previous holder panicked while holding it.
+    ///
+    /// In practice the lock is never held across user code, so poisoning cannot occur; recovering
+    /// rather than propagating keeps this type from ever panicking a caller.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Store> {
+        self.data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Set `key` to `value`, replacing any existing value for that key.
+    ///
+    /// Returns `&self` so calls can be chained.
+    pub fn set<T: Any + Send + Sync>(&self, key: impl Into<String>, value: T) -> &Self {
+        self.lock().insert(key.into(), Box::new(value));
+        self
+    }
+
+    /// Get a clone of the value stored at `key`, if present and of type `T`.
+    ///
+    /// Returns `None` if the key is absent or the stored value is not of type `T`. For values that
+    /// are not [`Clone`] (or that are expensive to clone), use [`with_mut`](Self::with_mut) or
+    /// [`take`](Self::take) instead.
+    pub fn get<T: Any + Send + Sync + Clone>(&self, key: &str) -> Option<T> {
+        self.lock()
+            .get(key)
+            .and_then(|value| value.downcast_ref::<T>())
+            .cloned()
+    }
+
+    /// Remove the value stored at `key` and return it, if present and of type `T`.
+    ///
+    /// This gives ownership of the value without requiring `T: Clone`, which is the natural way to
+    /// consume state set in an earlier stage — for example, taking an OpenTelemetry span in `after`
+    /// to end it. If the key is absent or the value is not of type `T`, returns `None` and leaves
+    /// the store unchanged.
+    pub fn take<T: Any + Send + Sync>(&self, key: &str) -> Option<T> {
+        let mut guard = self.lock();
+        // Only remove if the stored type matches, so a wrong-type call is non-destructive.
+        match guard.get(key).map(|value| value.is::<T>()) {
+            Some(true) => guard
+                .remove(key)
+                .and_then(|value| value.downcast::<T>().ok())
+                .map(|boxed| *boxed),
+            _ => None,
+        }
+    }
+
+    /// Invoke `f` with a mutable reference to the value at `key`, if present and of type `T`, and
+    /// return its result.
+    ///
+    /// This allows in-place mutation of non-[`Clone`] values — ending a span, pushing onto an
+    /// accumulated `Vec`, etc. — without removing them from the store. Returns `None` if the key is
+    /// absent or the value is not of type `T`.
+    ///
+    /// The internal lock is held for the duration of `f`, so `f` must not call back into the same
+    /// `HookData` instance (doing so would deadlock).
+    pub fn with_mut<T: Any + Send + Sync, R>(
+        &self,
+        key: &str,
+        f: impl FnOnce(&mut T) -> R,
+    ) -> Option<R> {
+        self.lock()
+            .get_mut(key)
+            .and_then(|value| value.downcast_mut::<T>())
+            .map(f)
+    }
+
+    /// Return `true` if `key` has a value set.
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.lock().contains_key(key)
+    }
+
+    /// Remove the value stored at `key`.
+    pub fn remove(&self, key: &str) {
+        self.lock().remove(key);
+    }
+
+    /// Return the number of values currently stored.
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// Return `true` if no values are stored.
+    pub fn is_empty(&self) -> bool {
+        self.lock().is_empty()
+    }
+}
+
+impl std::fmt::Debug for HookData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The stored values are type-erased and not necessarily `Debug`, so only expose the keys.
+        let guard = self.lock();
+        f.debug_struct("HookData")
+            .field("keys", &guard.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_get_roundtrip_various_types() {
+        let data = HookData::new();
+        data.set("string", "value".to_string());
+        data.set("int", 42_i64);
+        data.set("bool", true);
+
+        assert_eq!(data.get::<String>("string"), Some("value".to_string()));
+        assert_eq!(data.get::<i64>("int"), Some(42));
+        assert_eq!(data.get::<bool>("bool"), Some(true));
+    }
+
+    #[test]
+    fn get_missing_key_returns_none() {
+        let data = HookData::new();
+        assert_eq!(data.get::<i64>("absent"), None);
+    }
+
+    #[test]
+    fn get_wrong_type_returns_none() {
+        let data = HookData::new();
+        data.set("key", 42_i64);
+        assert_eq!(data.get::<String>("key"), None);
+    }
+
+    #[test]
+    fn set_overwrites_existing_value() {
+        let data = HookData::new();
+        data.set("key", 1_i64);
+        data.set("key", 2_i64);
+        assert_eq!(data.get::<i64>("key"), Some(2));
+    }
+
+    #[test]
+    fn set_is_chainable() {
+        let data = HookData::new();
+        data.set("a", 1_i64).set("b", 2_i64);
+        assert_eq!(data.get::<i64>("a"), Some(1));
+        assert_eq!(data.get::<i64>("b"), Some(2));
+    }
+
+    #[test]
+    fn contains_remove_len_is_empty() {
+        let data = HookData::new();
+        assert!(data.is_empty());
+        data.set("key", 1_i64);
+        assert!(data.contains_key("key"));
+        assert_eq!(data.len(), 1);
+        data.remove("key");
+        assert!(!data.contains_key("key"));
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn clone_shares_underlying_storage() {
+        let data = HookData::new();
+        let handle = data.clone();
+        data.set("key", 7_i64);
+        // The clone observes the write because both point at the same storage.
+        assert_eq!(handle.get::<i64>("key"), Some(7));
+    }
+
+    #[test]
+    fn supports_non_primitive_values() {
+        #[derive(Clone, PartialEq, Debug)]
+        struct Span {
+            id: u64,
+        }
+
+        let data = HookData::new();
+        data.set("span", Span { id: 99 });
+        assert_eq!(data.get::<Span>("span"), Some(Span { id: 99 }));
+    }
+
+    // A deliberately non-`Clone` type standing in for something like an OpenTelemetry span that
+    // must be mutated in place and consumed, never cloned.
+    #[derive(PartialEq, Debug)]
+    struct NotClone {
+        ended: bool,
+    }
+
+    #[test]
+    fn take_returns_ownership_without_clone() {
+        let data = HookData::new();
+        data.set("span", NotClone { ended: false });
+
+        let taken = data.take::<NotClone>("span");
+        assert_eq!(taken, Some(NotClone { ended: false }));
+        // The value is gone after taking.
+        assert!(!data.contains_key("span"));
+    }
+
+    #[test]
+    fn take_wrong_type_is_non_destructive() {
+        let data = HookData::new();
+        data.set("key", 42_i64);
+
+        assert!(data.take::<String>("key").is_none());
+        // Original value survives a wrong-type take.
+        assert_eq!(data.get::<i64>("key"), Some(42));
+    }
+
+    #[test]
+    fn take_missing_key_returns_none() {
+        let data = HookData::new();
+        assert!(data.take::<i64>("absent").is_none());
+    }
+
+    #[test]
+    fn with_mut_mutates_non_clone_value_in_place() {
+        let data = HookData::new();
+        data.set("span", NotClone { ended: false });
+
+        let result = data.with_mut::<NotClone, _>("span", |span| {
+            span.ended = true;
+            "ended"
+        });
+        assert_eq!(result, Some("ended"));
+
+        // The mutation persisted and the value is still stored.
+        assert_eq!(
+            data.with_mut::<NotClone, _>("span", |span| span.ended),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn with_mut_accumulates_across_calls() {
+        let data = HookData::new();
+        data.set("results", Vec::<String>::new());
+
+        data.with_mut::<Vec<String>, _>("results", |v| v.push("first".to_string()));
+        data.with_mut::<Vec<String>, _>("results", |v| v.push("second".to_string()));
+
+        assert_eq!(
+            data.get::<Vec<String>>("results"),
+            Some(vec!["first".to_string(), "second".to_string()])
+        );
+    }
+
+    #[test]
+    fn with_mut_missing_or_wrong_type_returns_none() {
+        let data = HookData::new();
+        data.set("key", 1_i64);
+
+        assert_eq!(data.with_mut::<i64, _>("absent", |v| *v), None);
+        assert_eq!(data.with_mut::<String, _>("key", |v| v.clone()), None);
+    }
+
+    #[test]
+    fn store_remains_usable_after_panic_in_with_mut() {
+        let data = HookData::new();
+        data.set("key", 1_i64);
+
+        // `with_mut` holds the internal lock across the closure, so panicking here poisons it.
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            data.with_mut::<i64, _>("key", |_| panic!("boom"));
+        }));
+        assert!(panicked.is_err());
+
+        // The store recovers the poisoned guard rather than propagating, so it stays usable.
+        assert_eq!(data.get::<i64>("key"), Some(1));
+        data.set("other", 2_i64);
+        assert_eq!(data.get::<i64>("other"), Some(2));
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -5,6 +5,9 @@ use crate::{
     EvaluationError, Type, Value,
 };
 
+mod data;
+pub use data::HookData;
+
 mod logging;
 pub use logging::LoggingHook;
 
@@ -93,8 +96,20 @@ pub struct HookHints {
 // ============================================================
 
 /// Context for hooks.
+///
+/// Implementing a [`Hook`] does not require constructing this type — the SDK builds it and passes a
+/// `&HookContext` into each stage. Code that *does* build one with a struct literal (tests, custom
+/// hook harnesses) must populate every field, including [`data`](Self::data):
+///
+/// ```ignore
+/// HookContext {
+///     // ...other fields...
+///     data: HookData::default(),
+/// }
+/// ```
+///
 #[allow(missing_docs)]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone)]
 pub struct HookContext<'a> {
     pub flag_key: &'a str,
     pub flag_type: Type,
@@ -102,6 +117,37 @@ pub struct HookContext<'a> {
     pub provider_metadata: ProviderMetadata,
     pub default_value: Option<Value>,
     pub client_metadata: ClientMetadata,
+    /// Mutable, per-hook-instance data shared across this hook's stages within a single evaluation.
+    ///
+    /// See [`HookData`] for details on lifetime and isolation semantics.
+    pub data: HookData,
+}
+
+// `HookData` holds type-erased values that are neither comparable nor necessarily `Debug`, so both
+// impls deliberately exclude it. Two hook contexts are equal when their immutable fields match.
+impl PartialEq for HookContext<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.flag_key == other.flag_key
+            && self.flag_type == other.flag_type
+            && self.evaluation_context == other.evaluation_context
+            && self.provider_metadata == other.provider_metadata
+            && self.default_value == other.default_value
+            && self.client_metadata == other.client_metadata
+    }
+}
+
+impl std::fmt::Debug for HookContext<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HookContext")
+            .field("flag_key", &self.flag_key)
+            .field("flag_type", &self.flag_type)
+            .field("evaluation_context", &self.evaluation_context)
+            .field("provider_metadata", &self.provider_metadata)
+            .field("default_value", &self.default_value)
+            .field("client_metadata", &self.client_metadata)
+            .field("data", &self.data)
+            .finish()
+    }
 }
 
 #[cfg(test)]
@@ -118,7 +164,7 @@ mod tests {
 
     #[spec(
         number = "4.1.1",
-        text = "Hook context MUST provide: the flag key, flag value type, evaluation context, and the default value."
+        text = "Hook context MUST provide: the flag key, flag value type, evaluation context, default value, and hook data."
     )]
     #[spec(
         number = "4.1.2",
@@ -137,6 +183,7 @@ mod tests {
             provider_metadata: ProviderMetadata::default(),
             default_value: Some(Value::Bool(true)),
             client_metadata: ClientMetadata::default(),
+            data: HookData::default(),
         };
 
         assert_eq!(context.flag_key, "flag_key");
@@ -145,6 +192,36 @@ mod tests {
         assert_eq!(context.provider_metadata, ProviderMetadata::default());
         assert_eq!(context.default_value, Some(Value::Bool(true)));
         assert_eq!(context.client_metadata, ClientMetadata::default());
+        assert!(context.data.is_empty());
+    }
+
+    #[spec(
+        number = "4.1.5",
+        text = "The hook data MUST be mutable. Either the hook data reference itself must be mutable, or it must allow mutation of its contents."
+    )]
+    #[spec(
+        number = "4.6.1",
+        text = "hook data MUST be a structure supporting the definition of arbitrary properties, with keys of type string, and values of any type."
+    )]
+    #[test]
+    fn hook_data_arbitrary_mutable_content() {
+        // Content is mutable through a shared `&` reference (interior mutability), and values may be
+        // of any `'static + Send + Sync` type, not just the restricted `Value` variants.
+        let data = HookData::default();
+        data.set("string", "value".to_string());
+        data.set("int", 42_i64);
+        data.set("tuple", (1_i32, "two".to_string()));
+
+        assert_eq!(data.get::<String>("string").as_deref(), Some("value"));
+        assert_eq!(data.get::<i64>("int"), Some(42));
+        assert_eq!(
+            data.get::<(i32, String)>("tuple"),
+            Some((1, "two".to_string()))
+        );
+
+        // Mutation of existing content is observable.
+        data.set("int", 43_i64);
+        assert_eq!(data.get::<i64>("int"), Some(43));
     }
 
     #[spec(
@@ -259,6 +336,7 @@ mod tests {
                     default_value: Some(Value::Bool(false)),
                     provider_metadata: ProviderMetadata::default(),
                     client_metadata: client_metadata.clone(),
+                    data: HookData::default(),
                 };
 
                 assert_eq!(ctx, &hook_ctx_1);
@@ -283,6 +361,7 @@ mod tests {
                     default_value: Some(Value::Bool(false)),
                     provider_metadata: ProviderMetadata::default(),
                     client_metadata: client_metadata.clone(),
+                    data: HookData::default(),
                 };
 
                 assert_eq!(ctx, &hook_ctx_1);
@@ -890,5 +969,379 @@ mod tests {
             code: EvaluationErrorCode::General("error".to_string()),
             message: None,
         })
+    }
+
+    #[spec(
+        number = "4.3.2",
+        text = "Hook data MUST be created before the first stage invoked in a hook for a specific evaluation and propagated between each stage of the hook. The hook data is not shared between different hooks."
+    )]
+    #[tokio::test]
+    async fn hook_data_shared_across_stages_success() {
+        struct StateSharingHook {
+            stages_run: Arc<std::sync::Mutex<Vec<String>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl Hook for StateSharingHook {
+            async fn before<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<Option<EvaluationContext>, EvaluationError> {
+                context
+                    .data
+                    .set("shared_key", "hello from before".to_string());
+                self.stages_run.lock().unwrap().push("before".to_string());
+                Ok(None)
+            }
+
+            async fn after<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<(), EvaluationError> {
+                let val = context.data.get::<String>("shared_key");
+                assert_eq!(val.as_deref(), Some("hello from before"));
+                self.stages_run.lock().unwrap().push("after".to_string());
+                Ok(())
+            }
+
+            async fn error<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _error: &EvaluationError,
+                _hints: Option<&'a HookHints>,
+            ) {
+                let val = context.data.get::<String>("shared_key");
+                assert_eq!(val.as_deref(), Some("hello from before"));
+                self.stages_run.lock().unwrap().push("error".to_string());
+            }
+
+            async fn finally<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _evaluation_details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) {
+                let val = context.data.get::<String>("shared_key");
+                assert_eq!(val.as_deref(), Some("hello from before"));
+                self.stages_run.lock().unwrap().push("finally".to_string());
+            }
+        }
+
+        let stages = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let hook = StateSharingHook {
+            stages_run: Arc::clone(&stages),
+        };
+
+        let mut api = OpenFeature::default();
+        let client = api.create_named_client("test").with_hook(hook);
+
+        let mut mock_provider = MockFeatureProvider::default();
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        mock_provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        let result = client.get_bool_value("flag", None, None).await;
+        assert!(result.is_ok());
+
+        let stages_run = stages.lock().unwrap();
+        assert_eq!(*stages_run, vec!["before", "after", "finally"]);
+    }
+
+    #[spec(
+        number = "4.3.2",
+        text = "Hook data MUST be created before the first stage invoked in a hook for a specific evaluation and propagated between each stage of the hook. The hook data is not shared between different hooks."
+    )]
+    #[tokio::test]
+    async fn hook_data_shared_across_stages_error() {
+        struct StateSharingHook {
+            stages_run: Arc<std::sync::Mutex<Vec<String>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl Hook for StateSharingHook {
+            async fn before<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<Option<EvaluationContext>, EvaluationError> {
+                context.data.set("shared_key", "error context".to_string());
+                self.stages_run.lock().unwrap().push("before".to_string());
+                Ok(None)
+            }
+
+            async fn after<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<(), EvaluationError> {
+                let val = context.data.get::<String>("shared_key");
+                assert_eq!(val.as_deref(), Some("error context"));
+                self.stages_run.lock().unwrap().push("after".to_string());
+                Ok(())
+            }
+
+            async fn error<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _error: &EvaluationError,
+                _hints: Option<&'a HookHints>,
+            ) {
+                let val = context.data.get::<String>("shared_key");
+                assert_eq!(val.as_deref(), Some("error context"));
+                self.stages_run.lock().unwrap().push("error".to_string());
+            }
+
+            async fn finally<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _evaluation_details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) {
+                let val = context.data.get::<String>("shared_key");
+                assert_eq!(val.as_deref(), Some("error context"));
+                self.stages_run.lock().unwrap().push("finally".to_string());
+            }
+        }
+
+        let stages = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let hook = StateSharingHook {
+            stages_run: Arc::clone(&stages),
+        };
+
+        let mut api = OpenFeature::default();
+        let client = api.create_named_client("test").with_hook(hook);
+
+        let mut mock_provider = MockFeatureProvider::default();
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        mock_provider
+            .expect_resolve_bool_value()
+            .return_const(Err(EvaluationError {
+                code: EvaluationErrorCode::FlagNotFound,
+                message: Some("flag not found".to_string()),
+            }));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        let result = client.get_bool_value("flag", None, None).await;
+        assert!(result.is_err());
+
+        let stages_run = stages.lock().unwrap();
+        assert_eq!(*stages_run, vec!["before", "error", "finally"]);
+    }
+
+    #[spec(
+        number = "4.3.2",
+        text = "Hook data MUST be created before the first stage invoked in a hook for a specific evaluation and propagated between each stage of the hook. The hook data is not shared between different hooks."
+    )]
+    #[tokio::test]
+    async fn hook_data_isolated_between_hooks() {
+        // Each hook writes its own `id` under the SAME key in `before`, then in `after` asserts it
+        // reads back exactly what it wrote — proving hooks do not share a hook data instance.
+        struct IsolationHook {
+            id: &'static str,
+            violations: Arc<std::sync::Mutex<Vec<String>>>,
+            checks: Arc<std::sync::atomic::AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl Hook for IsolationHook {
+            async fn before<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<Option<EvaluationContext>, EvaluationError> {
+                context.data.set("owner", self.id.to_string());
+                Ok(None)
+            }
+
+            async fn after<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<(), EvaluationError> {
+                // A leak from another hook would surface a different owner here.
+                if context.data.get::<String>("owner").as_deref() != Some(self.id) {
+                    self.violations.lock().unwrap().push(self.id.to_string());
+                }
+                self.checks
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            }
+
+            async fn error<'a>(
+                &self,
+                _context: &HookContext<'a>,
+                _error: &EvaluationError,
+                _hints: Option<&'a HookHints>,
+            ) {
+            }
+
+            async fn finally<'a>(
+                &self,
+                _context: &HookContext<'a>,
+                _evaluation_details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) {
+            }
+        }
+
+        let violations = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let checks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let mut api = OpenFeature::default();
+        let client = api
+            .create_named_client("test")
+            .with_hook(IsolationHook {
+                id: "hook_a",
+                violations: Arc::clone(&violations),
+                checks: Arc::clone(&checks),
+            })
+            .with_hook(IsolationHook {
+                id: "hook_b",
+                violations: Arc::clone(&violations),
+                checks: Arc::clone(&checks),
+            });
+
+        let mut mock_provider = MockFeatureProvider::default();
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        mock_provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        let result = client.get_bool_value("flag", None, None).await;
+        assert!(result.is_ok());
+
+        // Without this the test would pass vacuously: `violations` is also empty when no hook ran.
+        assert_eq!(
+            checks.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected both hooks to reach `after` and check their data"
+        );
+        let violations = violations.lock().unwrap();
+        assert!(
+            violations.is_empty(),
+            "hooks observed another hook's data: {violations:?}"
+        );
+    }
+
+    #[spec(
+        number = "4.3.2",
+        text = "Hook data MUST be created before the first stage invoked in a hook for a specific evaluation and propagated between each stage of the hook. The hook data is not shared between different hooks."
+    )]
+    #[tokio::test]
+    async fn hook_data_not_shared_between_evaluations() {
+        // The SAME hook instance is reused across evaluations, but each evaluation must start with
+        // a fresh, empty `HookData`. A `before` stage that observes a marker left by a previous
+        // evaluation would prove data leaked across evaluations.
+        struct PerEvaluationHook {
+            leaked: Arc<std::sync::atomic::AtomicBool>,
+            evaluations: Arc<std::sync::atomic::AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl Hook for PerEvaluationHook {
+            async fn before<'a>(
+                &self,
+                context: &HookContext<'a>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<Option<EvaluationContext>, EvaluationError> {
+                self.evaluations
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // Nothing from a prior evaluation should be visible here.
+                if context.data.contains_key("marker") {
+                    self.leaked.store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+                context.data.set("marker", true);
+                Ok(None)
+            }
+
+            async fn after<'a>(
+                &self,
+                _context: &HookContext<'a>,
+                _details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) -> Result<(), EvaluationError> {
+                Ok(())
+            }
+
+            async fn error<'a>(
+                &self,
+                _context: &HookContext<'a>,
+                _error: &EvaluationError,
+                _hints: Option<&'a HookHints>,
+            ) {
+            }
+
+            async fn finally<'a>(
+                &self,
+                _context: &HookContext<'a>,
+                _evaluation_details: &EvaluationDetails<Value>,
+                _hints: Option<&'a HookHints>,
+            ) {
+            }
+        }
+
+        let leaked = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let evaluations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let mut api = OpenFeature::default();
+        let client = api
+            .create_named_client("test")
+            .with_hook(PerEvaluationHook {
+                leaked: Arc::clone(&leaked),
+                evaluations: Arc::clone(&evaluations),
+            });
+
+        let mut mock_provider = MockFeatureProvider::default();
+        mock_provider.expect_hooks().return_const(vec![]);
+        mock_provider.expect_initialize().return_const(());
+        mock_provider
+            .expect_metadata()
+            .return_const(ProviderMetadata::default());
+        mock_provider
+            .expect_resolve_bool_value()
+            .return_const(Ok(ResolutionDetails::new(true)));
+
+        api.set_provider(mock_provider).await;
+        drop(api);
+
+        // Two evaluations with the same client (and thus the same hook instance).
+        assert!(client.get_bool_value("flag", None, None).await.is_ok());
+        assert!(client.get_bool_value("flag", None, None).await.is_ok());
+
+        assert_eq!(
+            evaluations.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected the hook to run for both evaluations"
+        );
+        assert!(
+            !leaked.load(std::sync::atomic::Ordering::SeqCst),
+            "hook data leaked from one evaluation into the next"
+        );
     }
 }


### PR DESCRIPTION
## This PR

- Implements **Hook Data** [spec 4.6](https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md#46-hook-data): a per-hook, per-evaluation key-value store on `HookContext` (`context.data`) that lets a hook carry state across its own stages. e.g. start a timer or open a telemetry span in `before` and finish it in `after`/`finally`
- Adds `HookData` with `set` / `get::<T>` / `take::<T>` / `with_mut::<T,_>`
- Each hook instance gets its own `HookData`, shared across that hook's `before` → `after`/`error` → `finally` stages and isolated from every other hook
- Adds a runnable example and a README "Hook data" subsection

## Related Issues

Closes #102

## Notes
- `HookContext` keeps `PartialEq`/`Debug` via manual impls that exclude the type-erased `data` field, so no trait impls are lost

## Follow-up Tasks

- None

## How to test

```shell
cargo test --features test-util
cargo run --example hook_data
```

Also verified: `cargo clippy -- -D warnings` and `cargo fmt --check` pass.
